### PR TITLE
Add CODEOWNERS for jredh to nexus repo

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# CODEOWNERS
+# Each line is a file pattern followed by one or more owners.
+# Order matters: the last matching rule wins.
+
+# Default owner for everything
+* @jredh


### PR DESCRIPTION
## Summary

add CODEOWNERS for jredh to nexus repo

## Changes

- **Commits**: 1 (will be squashed)
- **Changes**: 1 file changed, 6 insertions(+)

## Files Changed

- `+` .github/CODEOWNERS

---

*Auto-generated from workstream: workstream_80f8ef26-0750-4a68-a613-b4f4342be3d1*
