### PR TITLE
Fix Go version mismatch: bump Dockerfile and CI to Go 1.24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version: '1.24'
           cache: true
 
       - name: Check gofmt
@@ -49,7 +49,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version: '1.24'
           cache: true
 
       - name: Build nexus server
@@ -69,7 +69,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version: '1.24'
           cache: true
 
       - name: Run tests

--- a/services/portal/Dockerfile
+++ b/services/portal/Dockerfile
@@ -1,6 +1,6 @@
 # Build stage
 # Build context is the repo root (docker build -f services/portal/Dockerfile .)
-FROM golang:1.23-alpine AS builder
+FROM golang:1.24-alpine AS builder
 
 # Install build dependencies
 RUN apk add --no-cache git


### PR DESCRIPTION
## Summary

Fix Go version mismatch: bump Dockerfile and CI to Go 1.24

## Changes

- **Commits**: 1 (will be squashed)
- **Changes**: 2 files changed, 4 insertions(+), 4 deletions(-)

## Files Changed

- `~` .github/workflows/ci.yml
- `~` services/portal/Dockerfile

---

*Auto-generated from workstream: workstream_fe0e8e87-0411-4763-8a0e-ba40f42b6427*
