### PR TITLE
Fix cal deploy: increase memory to 512Mi for gen2 execution environment

### DIFF
--- a/.github/workflows/deploy-cal-dev.yml
+++ b/.github/workflows/deploy-cal-dev.yml
@@ -88,7 +88,7 @@ jobs:
             --execution-environment gen2 \
             --allow-unauthenticated \
             --port 8085 \
-            --memory 256Mi \
+            --memory 512Mi \
             --cpu 1 \
             --min-instances 0 \
             --max-instances 3 \

--- a/services/cal/terraform/environments/dev/main.tf
+++ b/services/cal/terraform/environments/dev/main.tf
@@ -66,7 +66,7 @@ module "cloud_run" {
   gcs_bucket = google_storage_bucket.cal_data.name
   mount_path = "/data"
 
-  memory        = "256Mi"
+  memory        = "512Mi"
   cpu           = "1"
   min_instances = 0
   max_instances = 3

--- a/services/cal/terraform/modules/cloud-run-gcs/main.tf
+++ b/services/cal/terraform/modules/cloud-run-gcs/main.tf
@@ -53,7 +53,7 @@ variable "mount_path" {
 
 variable "memory" {
   type    = string
-  default = "256Mi"
+  default = "512Mi"
 }
 
 variable "cpu" {


### PR DESCRIPTION
## Summary

fix cal deploy: increase memory to 512Mi for gen2 execution environment

## Changes

- **Commits**: 13 (will be squashed)
- **Changes**: 36 files changed, 2477 insertions(+), 1327 deletions(-)

## Files Changed

- `~` .github/workflows/ci.yml
- `+` .github/workflows/deploy-cal-dev.yml
- `~` .gitignore
- `~` CHANGELOG.md
- `~` go.mod
- `~` go.sum
- `+` services/cal/Dockerfile
- `+` services/cal/cmd/server/main.go
- `+` services/cal/config/config.go
- `+` services/cal/internal/database/database.go
- `+` services/cal/internal/database/database_test.go
- `+` services/cal/internal/handlers/handlers.go
- `+` services/cal/internal/handlers/handlers_test.go
- `+` services/cal/internal/ical/ical.go
- `+` services/cal/internal/ical/ical_test.go
- `+` services/cal/terraform/environments/dev/backend.tf
- `+` services/cal/terraform/environments/dev/main.tf
- `+` services/cal/terraform/environments/dev/outputs.tf
- `+` services/cal/terraform/environments/dev/variables.tf
- `+` services/cal/terraform/modules/cloud-run-gcs/main.tf
- `~` services/portal/.env.example
- `~` services/portal/Dockerfile
- `~` services/portal/cmd/server/main.go
- `~` services/portal/config/config.go
- `+` services/portal/docker-compose.yml
- `~` services/portal/internal/auth/errors.go
- `~` services/portal/internal/auth/service.go
- `~` services/portal/internal/database/database.go
- `-` services/portal/internal/token/service.go
- `~` services/portal/internal/web/handlers/handlers.go
- `~` services/portal/internal/web/handlers/middleware.go
- `~` services/portal/internal/web/templates/base.html
- `+` services/portal/internal/web/templates/dashboard.html
- `~` services/portal/internal/web/templates/home.html
- `~` services/portal/internal/web/templates/login.html
- `~` services/portal/pkg/models/models.go

---

*Auto-generated from workstream: workstream_79b9232c-5d46-4a90-81e4-a142ae698882*
