### PR TITLE
Fix cal API: add json tags to database structs, remove redundant /cal/ prefix from ics URL path

### DIFF
--- a/services/cal/cmd/server/main.go
+++ b/services/cal/cmd/server/main.go
@@ -68,8 +68,8 @@ func main() {
 	})
 
 	// Calendar subscription endpoint (served to calendar clients)
-	// webcal://host/cal/{token}.ics
-	r.Get("/cal/{token}.ics", h.Subscribe)
+	// webcal://host/{token}.ics
+	r.Get("/{token}.ics", h.Subscribe)
 
 	// Management API
 	r.Route("/api", func(r chi.Router) {
@@ -106,7 +106,7 @@ func main() {
 	}()
 
 	log.Printf("nexus-cal starting on %s", addr)
-	log.Printf("  Subscribe: webcal://localhost%s/cal/{token}.ics", addr)
+	log.Printf("  Subscribe: webcal://localhost%s/{token}.ics", addr)
 	log.Printf("  API:       http://localhost%s/api/", addr)
 
 	if err := srv.ListenAndServe(); err != http.ErrServerClosed {

--- a/services/cal/internal/database/database.go
+++ b/services/cal/internal/database/database.go
@@ -15,29 +15,29 @@ type DB struct {
 
 // Feed represents a calendar feed with a unique subscription token.
 type Feed struct {
-	ID        string
-	Name      string
-	Token     string // unguessable token for subscription URL
-	CreatedAt time.Time
-	UpdatedAt time.Time
+	ID        string    `json:"id"`
+	Name      string    `json:"name"`
+	Token     string    `json:"token"` // unguessable token for subscription URL
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
 }
 
 // Event represents a single calendar event within a feed.
 type Event struct {
-	ID          string
-	FeedID      string
-	Summary     string
-	Description string
-	Location    string
-	URL         string
-	Start       time.Time
-	End         *time.Time // nil = no end time (all-day or point-in-time)
-	AllDay      bool
-	Deadline    *time.Time // optional deadline (used as DTSTART if set, with VALARM)
-	Status      string     // TENTATIVE, CONFIRMED, CANCELLED
-	Categories  string     // comma-separated
-	CreatedAt   time.Time
-	UpdatedAt   time.Time
+	ID          string     `json:"id"`
+	FeedID      string     `json:"feed_id"`
+	Summary     string     `json:"summary"`
+	Description string     `json:"description"`
+	Location    string     `json:"location"`
+	URL         string     `json:"url"`
+	Start       time.Time  `json:"start"`
+	End         *time.Time `json:"end,omitempty"` // nil = no end time (all-day or point-in-time)
+	AllDay      bool       `json:"all_day"`
+	Deadline    *time.Time `json:"deadline,omitempty"` // optional deadline (used as DTSTART if set, with VALARM)
+	Status      string     `json:"status"`             // TENTATIVE, CONFIRMED, CANCELLED
+	Categories  string     `json:"categories"`         // comma-separated
+	CreatedAt   time.Time  `json:"created_at"`
+	UpdatedAt   time.Time  `json:"updated_at"`
 }
 
 const schema = `

--- a/services/cal/internal/handlers/handlers.go
+++ b/services/cal/internal/handlers/handlers.go
@@ -31,7 +31,7 @@ func New(db *database.DB) *Handler {
 // --- Subscription endpoint (served to calendar clients) ---
 
 // Subscribe serves the iCal feed for a given token.
-// GET /cal/{token}.ics
+// GET /{token}.ics
 func (h *Handler) Subscribe(w http.ResponseWriter, r *http.Request) {
 	token := chi.URLParam(r, "token")
 	if token == "" {
@@ -144,7 +144,7 @@ func (h *Handler) CreateFeed(w http.ResponseWriter, r *http.Request) {
 		ID:    feed.ID,
 		Name:  feed.Name,
 		Token: feed.Token,
-		URL:   "/cal/" + feed.Token + ".ics",
+		URL:   "/" + feed.Token + ".ics",
 	}
 	jsonOK(w, http.StatusCreated, resp)
 }

--- a/services/cal/internal/handlers/handlers_test.go
+++ b/services/cal/internal/handlers/handlers_test.go
@@ -30,7 +30,7 @@ func testHandler(t *testing.T) *Handler {
 
 func testRouter(h *Handler) *chi.Mux {
 	r := chi.NewRouter()
-	r.Get("/cal/{token}.ics", h.Subscribe)
+	r.Get("/{token}.ics", h.Subscribe)
 	r.Route("/api", func(r chi.Router) {
 		r.Post("/feeds", h.CreateFeed)
 		r.Get("/feeds", h.ListFeeds)
@@ -123,7 +123,7 @@ func TestCreateEventAndSubscribe(t *testing.T) {
 	}
 
 	// Subscribe to the feed
-	req = httptest.NewRequest(http.MethodGet, "/cal/"+feed.Token+".ics", nil)
+	req = httptest.NewRequest(http.MethodGet, "/"+feed.Token+".ics", nil)
 	w = httptest.NewRecorder()
 	r.ServeHTTP(w, req)
 
@@ -158,7 +158,7 @@ func TestSubscribe_InvalidToken(t *testing.T) {
 	h := testHandler(t)
 	r := testRouter(h)
 
-	req := httptest.NewRequest(http.MethodGet, "/cal/nonexistent.ics", nil)
+	req := httptest.NewRequest(http.MethodGet, "/nonexistent.ics", nil)
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
 
@@ -278,12 +278,12 @@ func TestCreateFeed_WithSlug(t *testing.T) {
 	if created.Token != "my-calendar" {
 		t.Errorf("expected token 'my-calendar', got %q", created.Token)
 	}
-	if created.URL != "/cal/my-calendar.ics" {
-		t.Errorf("expected URL '/cal/my-calendar.ics', got %q", created.URL)
+	if created.URL != "/my-calendar.ics" {
+		t.Errorf("expected URL '/my-calendar.ics', got %q", created.URL)
 	}
 
 	// Subscribe using the slug
-	req = httptest.NewRequest(http.MethodGet, "/cal/my-calendar.ics", nil)
+	req = httptest.NewRequest(http.MethodGet, "/my-calendar.ics", nil)
 	w = httptest.NewRecorder()
 	r.ServeHTTP(w, req)
 


### PR DESCRIPTION
## Summary

fix cal API: add json tags to database structs, remove redundant /cal/ prefix from ics URL path

## Changes

- **Commits**: 15 (will be squashed)
- **Changes**: 36 files changed, 2618 insertions(+), 1327 deletions(-)

## Files Changed

- `~` .github/workflows/ci.yml
- `+` .github/workflows/deploy-cal-dev.yml
- `~` .gitignore
- `~` CHANGELOG.md
- `~` go.mod
- `~` go.sum
- `+` services/cal/Dockerfile
- `+` services/cal/cmd/server/main.go
- `+` services/cal/config/config.go
- `+` services/cal/internal/database/database.go
- `+` services/cal/internal/database/database_test.go
- `+` services/cal/internal/handlers/handlers.go
- `+` services/cal/internal/handlers/handlers_test.go
- `+` services/cal/internal/ical/ical.go
- `+` services/cal/internal/ical/ical_test.go
- `+` services/cal/terraform/environments/dev/backend.tf
- `+` services/cal/terraform/environments/dev/main.tf
- `+` services/cal/terraform/environments/dev/outputs.tf
- `+` services/cal/terraform/environments/dev/variables.tf
- `+` services/cal/terraform/modules/cloud-run-gcs/main.tf
- `~` services/portal/.env.example
- `~` services/portal/Dockerfile
- `~` services/portal/cmd/server/main.go
- `~` services/portal/config/config.go
- `+` services/portal/docker-compose.yml
- `~` services/portal/internal/auth/errors.go
- `~` services/portal/internal/auth/service.go
- `~` services/portal/internal/database/database.go
- `-` services/portal/internal/token/service.go
- `~` services/portal/internal/web/handlers/handlers.go
- `~` services/portal/internal/web/handlers/middleware.go
- `~` services/portal/internal/web/templates/base.html
- `+` services/portal/internal/web/templates/dashboard.html
- `~` services/portal/internal/web/templates/home.html
- `~` services/portal/internal/web/templates/login.html
- `~` services/portal/pkg/models/models.go

---

*Auto-generated from workstream: workstream_c7c9bcde-04ff-4feb-9987-b036061b6e91*
