### PR TITLE
Add roles-based auth, admin middleware, magic login links, permission tests

### DIFF
--- a/services/portal/internal/auth/errors.go
+++ b/services/portal/internal/auth/errors.go
@@ -10,4 +10,6 @@ var (
 	ErrEmailTaken         = errors.New("an account with this email already exists")
 	ErrPhoneTaken         = errors.New("an account with this phone number already exists")
 	ErrUsernameTaken      = errors.New("this username is already taken")
+	ErrInvalidMagicToken  = errors.New("invalid or expired magic login token")
+	ErrForbidden          = errors.New("forbidden: admin access required")
 )

--- a/services/portal/internal/database/database.go
+++ b/services/portal/internal/database/database.go
@@ -38,7 +38,7 @@ func (db *DB) Close() error {
 	return db.conn.Close()
 }
 
-// migrate creates tables if they do not exist.
+// migrate creates tables if they do not exist and applies schema updates.
 func migrate(conn *sql.DB) error {
 	const ddl = `
 	CREATE TABLE IF NOT EXISTS users (
@@ -47,6 +47,7 @@ func migrate(conn *sql.DB) error {
 		email         TEXT UNIQUE NOT NULL,
 		phone_number  TEXT NOT NULL DEFAULT '',
 		name          TEXT NOT NULL DEFAULT '',
+		role          TEXT NOT NULL DEFAULT 'user',
 		password_hash TEXT NOT NULL,
 		email_hash    TEXT NOT NULL DEFAULT '',
 		phone_hash    TEXT NOT NULL DEFAULT '',
@@ -70,19 +71,68 @@ func migrate(conn *sql.DB) error {
 
 	CREATE INDEX IF NOT EXISTS idx_sessions_user_id ON sessions(user_id);
 	CREATE INDEX IF NOT EXISTS idx_sessions_expires_at ON sessions(expires_at);
+
+	CREATE TABLE IF NOT EXISTS magic_tokens (
+		id         TEXT PRIMARY KEY,
+		user_id    TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+		expires_at DATETIME NOT NULL,
+		used_at    DATETIME,
+		created_at DATETIME NOT NULL
+	);
+
+	CREATE INDEX IF NOT EXISTS idx_magic_tokens_user_id ON magic_tokens(user_id);
 	`
-	_, err := conn.Exec(ddl)
+	if _, err := conn.Exec(ddl); err != nil {
+		return err
+	}
+
+	// Add role column to existing databases that lack it.
+	if err := addColumnIfNotExists(conn, "users", "role", "TEXT NOT NULL DEFAULT 'user'"); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// addColumnIfNotExists adds a column to a table if it does not already exist.
+// SQLite doesn't support IF NOT EXISTS for ALTER TABLE ADD COLUMN, so we
+// check the schema first.
+func addColumnIfNotExists(conn *sql.DB, table, column, colDef string) error {
+	rows, err := conn.Query(fmt.Sprintf("PRAGMA table_info(%s)", table))
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var cid int
+		var name, ctype string
+		var notnull int
+		var dfltValue sql.NullString
+		var pk int
+		if err := rows.Scan(&cid, &name, &ctype, &notnull, &dfltValue, &pk); err != nil {
+			return err
+		}
+		if name == column {
+			return nil // column already exists
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+
+	_, err = conn.Exec(fmt.Sprintf("ALTER TABLE %s ADD COLUMN %s %s", table, column, colDef))
 	return err
 }
 
 // userColumns is the SELECT column list for user queries.
-const userColumns = `id, username, email, phone_number, name, password_hash, email_hash, phone_hash, created_at, updated_at, last_login_at`
+const userColumns = `id, username, email, phone_number, name, role, password_hash, email_hash, phone_hash, created_at, updated_at, last_login_at`
 
 // scanUser scans a row into a User model.
 func scanUser(row interface{ Scan(...interface{}) error }) (*models.User, error) {
 	u := &models.User{}
 	err := row.Scan(
-		&u.ID, &u.Username, &u.Email, &u.PhoneNumber, &u.Name,
+		&u.ID, &u.Username, &u.Email, &u.PhoneNumber, &u.Name, &u.Role,
 		&u.PasswordHash, &u.EmailHash, &u.PhoneHash,
 		&u.CreatedAt, &u.UpdatedAt, &u.LastLoginAt,
 	)
@@ -96,10 +146,10 @@ func scanUser(row interface{ Scan(...interface{}) error }) (*models.User, error)
 
 // CreateUser inserts a new user.
 func (db *DB) CreateUser(u *models.User) error {
-	const q = `INSERT INTO users (id, username, email, phone_number, name, password_hash, email_hash, phone_hash, created_at, updated_at, last_login_at)
-	           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+	const q = `INSERT INTO users (id, username, email, phone_number, name, role, password_hash, email_hash, phone_hash, created_at, updated_at, last_login_at)
+	           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
 	_, err := db.conn.Exec(q,
-		u.ID, u.Username, u.Email, u.PhoneNumber, u.Name,
+		u.ID, u.Username, u.Email, u.PhoneNumber, u.Name, u.Role,
 		u.PasswordHash, u.EmailHash, u.PhoneHash,
 		u.CreatedAt, u.UpdatedAt, u.LastLoginAt,
 	)
@@ -196,4 +246,49 @@ func (db *DB) GetSessionsByUserID(userID string) ([]models.Session, error) {
 		sessions = append(sessions, s)
 	}
 	return sessions, rows.Err()
+}
+
+// --- Role operations ---
+
+// UpdateUserRole sets the role for a user.
+func (db *DB) UpdateUserRole(userID, role string) error {
+	const q = `UPDATE users SET role = ?, updated_at = ? WHERE id = ?`
+	_, err := db.conn.Exec(q, role, time.Now(), userID)
+	return err
+}
+
+// --- Magic token operations ---
+
+// CreateMagicToken inserts a new magic login token.
+func (db *DB) CreateMagicToken(t *models.MagicToken) error {
+	const q = `INSERT INTO magic_tokens (id, user_id, expires_at, created_at)
+	           VALUES (?, ?, ?, ?)`
+	_, err := db.conn.Exec(q, t.ID, t.UserID, t.ExpiresAt, t.CreatedAt)
+	return err
+}
+
+// GetMagicToken retrieves a magic token by ID if it is unused and not expired.
+func (db *DB) GetMagicToken(id string) (*models.MagicToken, error) {
+	const q = `SELECT id, user_id, expires_at, created_at
+	           FROM magic_tokens WHERE id = ? AND used_at IS NULL AND expires_at > ?`
+	t := &models.MagicToken{}
+	err := db.conn.QueryRow(q, id, time.Now()).Scan(&t.ID, &t.UserID, &t.ExpiresAt, &t.CreatedAt)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	return t, err
+}
+
+// ConsumeMagicToken marks a magic token as used.
+func (db *DB) ConsumeMagicToken(id string) error {
+	const q = `UPDATE magic_tokens SET used_at = ? WHERE id = ?`
+	_, err := db.conn.Exec(q, time.Now(), id)
+	return err
+}
+
+// DeleteExpiredMagicTokens cleans up tokens that have expired or been used.
+func (db *DB) DeleteExpiredMagicTokens() error {
+	const q = `DELETE FROM magic_tokens WHERE expires_at <= ? OR used_at IS NOT NULL`
+	_, err := db.conn.Exec(q, time.Now())
+	return err
 }

--- a/services/portal/pkg/models/models.go
+++ b/services/portal/pkg/models/models.go
@@ -2,6 +2,12 @@ package models
 
 import "time"
 
+// Role constants for user authorization.
+const (
+	RoleUser  = "user"
+	RoleAdmin = "admin"
+)
+
 // User represents a registered user.
 type User struct {
 	ID           string    `json:"id"`
@@ -9,12 +15,18 @@ type User struct {
 	Email        string    `json:"email"`
 	PhoneNumber  string    `json:"phone_number"`
 	Name         string    `json:"name"`
+	Role         string    `json:"role"`
 	PasswordHash string    `json:"-"`
 	EmailHash    string    `json:"-"`
 	PhoneHash    string    `json:"-"`
 	CreatedAt    time.Time `json:"created_at"`
 	UpdatedAt    time.Time `json:"updated_at"`
 	LastLoginAt  time.Time `json:"last_login_at"`
+}
+
+// IsAdmin returns true if the user has the admin role.
+func (u *User) IsAdmin() bool {
+	return u.Role == RoleAdmin
 }
 
 // Session represents an active user session.
@@ -25,4 +37,13 @@ type Session struct {
 	CreatedAt time.Time `json:"created_at"`
 	IPAddress string    `json:"ip_address"`
 	UserAgent string    `json:"user_agent"`
+}
+
+// MagicToken represents a one-time-use login token.
+type MagicToken struct {
+	ID        string    `json:"id"`
+	UserID    string    `json:"user_id"`
+	ExpiresAt time.Time `json:"expires_at"`
+	UsedAt    time.Time `json:"used_at,omitempty"`
+	CreatedAt time.Time `json:"created_at"`
 }

--- a/services/portal/tests/integration/admin_test.go
+++ b/services/portal/tests/integration/admin_test.go
@@ -1,0 +1,408 @@
+package integration
+
+import (
+	"net/http"
+	"net/http/cookiejar"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/jredh-dev/nexus/services/portal/config"
+	"github.com/jredh-dev/nexus/services/portal/internal/auth"
+	"github.com/jredh-dev/nexus/services/portal/internal/database"
+	"github.com/jredh-dev/nexus/services/portal/internal/web/handlers"
+	"github.com/jredh-dev/nexus/services/portal/pkg/models"
+)
+
+// testServerWithDB returns the full test server plus the raw DB and auth service
+// so tests can manipulate roles and create magic tokens.
+func testServerWithDB(t *testing.T) (srv *httptest.Server, client *http.Client, db *database.DB, authSvc *auth.Service, cleanup func()) {
+	t.Helper()
+
+	root := findMonorepoRoot(t)
+	origDir, _ := os.Getwd()
+	if err := os.Chdir(root); err != nil {
+		t.Fatalf("chdir to monorepo root: %v", err)
+	}
+
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	giveawayDBPath := filepath.Join(dir, "giveaway_test.db")
+
+	var err error
+	db, err = database.New(dbPath)
+	if err != nil {
+		t.Fatalf("open test db: %v", err)
+	}
+
+	giveawayDB, err := database.NewGiveaway(giveawayDBPath)
+	if err != nil {
+		t.Fatalf("open giveaway test db: %v", err)
+	}
+
+	cfg := &config.Config{
+		Server:   config.ServerConfig{Port: "0", Env: "test"},
+		DB:       config.DBConfig{Path: dbPath},
+		Giveaway: config.GiveawayConfig{DBPath: giveawayDBPath},
+		Session:  config.SessionConfig{Secret: "test-secret", MaxAge: 3600},
+	}
+
+	authSvc = auth.New(db, cfg)
+	h := handlers.New(db, giveawayDB, cfg, authSvc)
+
+	r := chi.NewRouter()
+	r.Get("/", h.Home)
+	r.Get("/login", h.LoginPage)
+	r.Post("/login", h.Login)
+	r.Get("/signup", h.SignupPage)
+	r.Post("/signup", h.Signup)
+	r.Get("/logout", h.Logout)
+	r.Get("/auth/magic", h.MagicLogin)
+	r.Group(func(r chi.Router) {
+		r.Use(handlers.AuthMiddleware(authSvc))
+		r.Get("/dashboard", h.Dashboard)
+	})
+	r.Group(func(r chi.Router) {
+		r.Use(handlers.AuthMiddleware(authSvc))
+		r.Use(handlers.AdminMiddleware)
+		r.Get("/admin/giveaway", h.AdminGiveawayList)
+		r.Post("/admin/magic-link", h.AdminGenerateMagicLink)
+	})
+
+	srv = httptest.NewServer(r)
+
+	jar, _ := cookiejar.New(nil)
+	client = &http.Client{
+		Jar: jar,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			if len(via) >= 10 {
+				return http.ErrUseLastResponse
+			}
+			return nil
+		},
+	}
+
+	cleanup = func() {
+		srv.Close()
+		db.Close()
+		giveawayDB.Close()
+		_ = os.Chdir(origDir)
+	}
+
+	return srv, client, db, authSvc, cleanup
+}
+
+// signupAndLogin creates a user via the signup form and returns with an active session.
+func signupAndLogin(t *testing.T, client *http.Client, srvURL, username, email, phone, password, name string) {
+	t.Helper()
+	resp, err := postForm(client, srvURL+"/signup", url.Values{
+		"username": {username},
+		"email":    {email},
+		"phone":    {phone},
+		"password": {password},
+		"name":     {name},
+	})
+	if err != nil {
+		t.Fatalf("signup %s: %v", email, err)
+	}
+	resp.Body.Close()
+}
+
+// --- Permission leakage tests ---
+
+func TestAdminRoutes_UnauthenticatedRedirectsToLogin(t *testing.T) {
+	srv, client, _, _, cleanup := testServerWithDB(t)
+	defer cleanup()
+
+	// Unauthenticated requests to admin routes should redirect to /login.
+	for _, path := range []string{"/admin/giveaway"} {
+		resp, err := client.Get(srv.URL + path)
+		if err != nil {
+			t.Fatalf("GET %s: %v", path, err)
+		}
+		resp.Body.Close()
+
+		if !strings.HasSuffix(resp.Request.URL.Path, "/login") {
+			t.Errorf("unauthenticated GET %s: landed on %s, want /login", path, resp.Request.URL.Path)
+		}
+	}
+}
+
+func TestAdminRoutes_NonAdminGetsForbidden(t *testing.T) {
+	srv, client, _, _, cleanup := testServerWithDB(t)
+	defer cleanup()
+
+	// Create a regular user and log in.
+	signupAndLogin(t, client, srv.URL, "regularuser", "regular@example.com", "5551111111", "password", "Regular User")
+
+	// Non-admin should get 403 on admin routes.
+	// We need a client that doesn't follow redirects for the admin check
+	// since AuthMiddleware does redirects but AdminMiddleware returns 403.
+	noRedirectClient := &http.Client{
+		Jar: client.Jar,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+
+	resp, err := noRedirectClient.Get(srv.URL + "/admin/giveaway")
+	if err != nil {
+		t.Fatalf("GET /admin/giveaway: %v", err)
+	}
+	resp.Body.Close()
+
+	if resp.StatusCode != http.StatusForbidden {
+		t.Errorf("non-admin GET /admin/giveaway: status = %d, want 403", resp.StatusCode)
+	}
+}
+
+func TestAdminRoutes_AdminCanAccess(t *testing.T) {
+	srv, client, db, _, cleanup := testServerWithDB(t)
+	defer cleanup()
+
+	// Create a user, promote to admin, log in.
+	signupAndLogin(t, client, srv.URL, "adminuser", "admin@example.com", "5552222222", "password", "Admin User")
+
+	// Look up and promote to admin.
+	user, err := db.GetUserByEmail("admin@example.com")
+	if err != nil || user == nil {
+		t.Fatalf("lookup admin user: %v", err)
+	}
+	if err := db.UpdateUserRole(user.ID, models.RoleAdmin); err != nil {
+		t.Fatalf("promote to admin: %v", err)
+	}
+
+	// Logout and re-login so the session picks up the new role.
+	resp, err := client.Get(srv.URL + "/logout")
+	if err != nil {
+		t.Fatalf("logout: %v", err)
+	}
+	resp.Body.Close()
+
+	resp, err = postForm(client, srv.URL+"/login", url.Values{
+		"email":    {"admin@example.com"},
+		"password": {"password"},
+	})
+	if err != nil {
+		t.Fatalf("login: %v", err)
+	}
+	resp.Body.Close()
+
+	// Admin should be able to access admin routes.
+	noRedirectClient := &http.Client{
+		Jar: client.Jar,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+
+	resp, err = noRedirectClient.Get(srv.URL + "/admin/giveaway")
+	if err != nil {
+		t.Fatalf("GET /admin/giveaway: %v", err)
+	}
+	resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("admin GET /admin/giveaway: status = %d, want 200", resp.StatusCode)
+	}
+}
+
+func TestMagicLogin_ValidToken(t *testing.T) {
+	srv, client, _, authSvc, cleanup := testServerWithDB(t)
+	defer cleanup()
+
+	// Create a user first.
+	_, err := authSvc.CreateUser("magic@example.com", "password", "Magic User")
+	if err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+
+	// Generate a magic token.
+	token, err := authSvc.CreateMagicToken("magic@example.com")
+	if err != nil {
+		t.Fatalf("create magic token: %v", err)
+	}
+
+	// Use the magic link to log in.
+	resp, err := client.Get(srv.URL + "/auth/magic?token=" + token)
+	if err != nil {
+		t.Fatalf("GET /auth/magic: %v", err)
+	}
+	resp.Body.Close()
+
+	// Should redirect to /dashboard.
+	if !strings.HasSuffix(resp.Request.URL.Path, "/dashboard") {
+		t.Errorf("magic login: landed on %s, want /dashboard", resp.Request.URL.Path)
+	}
+}
+
+func TestMagicLogin_InvalidToken(t *testing.T) {
+	srv, _, _, _, cleanup := testServerWithDB(t)
+	defer cleanup()
+
+	// Use a non-redirect client so we can see the 401.
+	jar, _ := cookiejar.New(nil)
+	client := &http.Client{
+		Jar: jar,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+
+	resp, err := client.Get(srv.URL + "/auth/magic?token=bogus-token-12345")
+	if err != nil {
+		t.Fatalf("GET /auth/magic: %v", err)
+	}
+	resp.Body.Close()
+
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("invalid magic token: status = %d, want 401", resp.StatusCode)
+	}
+}
+
+func TestMagicLogin_TokenCannotBeReused(t *testing.T) {
+	srv, _, _, authSvc, cleanup := testServerWithDB(t)
+	defer cleanup()
+
+	// Create a user.
+	_, err := authSvc.CreateUser("reuse@example.com", "password", "Reuse User")
+	if err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+
+	token, err := authSvc.CreateMagicToken("reuse@example.com")
+	if err != nil {
+		t.Fatalf("create magic token: %v", err)
+	}
+
+	// First use should work.
+	jar1, _ := cookiejar.New(nil)
+	client1 := &http.Client{
+		Jar: jar1,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			if len(via) >= 10 {
+				return http.ErrUseLastResponse
+			}
+			return nil
+		},
+	}
+	resp, err := client1.Get(srv.URL + "/auth/magic?token=" + token)
+	if err != nil {
+		t.Fatalf("first magic login: %v", err)
+	}
+	resp.Body.Close()
+
+	if !strings.HasSuffix(resp.Request.URL.Path, "/dashboard") {
+		t.Errorf("first use: landed on %s, want /dashboard", resp.Request.URL.Path)
+	}
+
+	// Second use should fail.
+	jar2, _ := cookiejar.New(nil)
+	client2 := &http.Client{
+		Jar: jar2,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+	resp, err = client2.Get(srv.URL + "/auth/magic?token=" + token)
+	if err != nil {
+		t.Fatalf("second magic login: %v", err)
+	}
+	resp.Body.Close()
+
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("reused magic token: status = %d, want 401", resp.StatusCode)
+	}
+}
+
+func TestMagicLogin_MissingToken(t *testing.T) {
+	srv, _, _, _, cleanup := testServerWithDB(t)
+	defer cleanup()
+
+	jar, _ := cookiejar.New(nil)
+	client := &http.Client{
+		Jar: jar,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+
+	resp, err := client.Get(srv.URL + "/auth/magic")
+	if err != nil {
+		t.Fatalf("GET /auth/magic: %v", err)
+	}
+	resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("missing token: status = %d, want 400", resp.StatusCode)
+	}
+}
+
+func TestAdminMagicLinkGeneration_NonAdminForbidden(t *testing.T) {
+	srv, client, _, _, cleanup := testServerWithDB(t)
+	defer cleanup()
+
+	// Create and login as regular user.
+	signupAndLogin(t, client, srv.URL, "linkuser", "link@example.com", "5553333333", "password", "Link User")
+
+	noRedirectClient := &http.Client{
+		Jar: client.Jar,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+
+	resp, err := noRedirectClient.Post(
+		srv.URL+"/admin/magic-link",
+		"application/x-www-form-urlencoded",
+		strings.NewReader(url.Values{"email": {"link@example.com"}}.Encode()),
+	)
+	if err != nil {
+		t.Fatalf("POST /admin/magic-link: %v", err)
+	}
+	resp.Body.Close()
+
+	if resp.StatusCode != http.StatusForbidden {
+		t.Errorf("non-admin magic-link generation: status = %d, want 403", resp.StatusCode)
+	}
+}
+
+func TestUserRole_DefaultIsUser(t *testing.T) {
+	_, _, db, authSvc, cleanup := testServerWithDB(t)
+	defer cleanup()
+
+	// Create a user via Signup (user-facing method).
+	user, err := authSvc.Signup("roletest", "role@example.com", "5554444444", "password", "Role Test")
+	if err != nil {
+		t.Fatalf("signup: %v", err)
+	}
+
+	if user.Role != models.RoleUser {
+		t.Errorf("new user role = %q, want %q", user.Role, models.RoleUser)
+	}
+
+	// Verify via DB lookup.
+	dbUser, err := db.GetUserByEmail("role@example.com")
+	if err != nil || dbUser == nil {
+		t.Fatalf("lookup user: %v", err)
+	}
+	if dbUser.Role != models.RoleUser {
+		t.Errorf("db user role = %q, want %q", dbUser.Role, models.RoleUser)
+	}
+
+	// Promote and verify.
+	if err := db.UpdateUserRole(dbUser.ID, models.RoleAdmin); err != nil {
+		t.Fatalf("update role: %v", err)
+	}
+	dbUser, _ = db.GetUserByEmail("role@example.com")
+	if dbUser.Role != models.RoleAdmin {
+		t.Errorf("after promotion role = %q, want %q", dbUser.Role, models.RoleAdmin)
+	}
+	if !dbUser.IsAdmin() {
+		t.Error("IsAdmin() returned false after promotion")
+	}
+}

--- a/services/portal/tests/integration/signup_test.go
+++ b/services/portal/tests/integration/signup_test.go
@@ -62,9 +62,16 @@ func testServer(t *testing.T) (srv *httptest.Server, client *http.Client, cleanu
 	r.Get("/signup", h.SignupPage)
 	r.Post("/signup", h.Signup)
 	r.Get("/logout", h.Logout)
+	r.Get("/auth/magic", h.MagicLogin)
 	r.Group(func(r chi.Router) {
 		r.Use(handlers.AuthMiddleware(authService))
 		r.Get("/dashboard", h.Dashboard)
+	})
+	r.Group(func(r chi.Router) {
+		r.Use(handlers.AuthMiddleware(authService))
+		r.Use(handlers.AdminMiddleware)
+		r.Get("/admin/giveaway", h.AdminGiveawayList)
+		r.Post("/admin/magic-link", h.AdminGenerateMagicLink)
 	})
 
 	srv = httptest.NewServer(r)


### PR DESCRIPTION
## Summary

Add roles-based auth, admin middleware, magic login links, permission tests

## Changes

- **Commits**: 5 (will be squashed)
- **Changes**: 30 files changed, 3237 insertions(+), 247 deletions(-)

## Files Changed

- `~` contact.yaml
- `~` services/portal/cmd/server/main.go
- `~` services/portal/config/config.go
- `~` services/portal/internal/auth/errors.go
- `~` services/portal/internal/auth/service.go
- `~` services/portal/internal/database/database.go
- `+` services/portal/internal/database/giveaway.go
- `+` services/portal/internal/database/giveaway_test.go
- `+` services/portal/internal/web/handlers/admin.go
- `+` services/portal/internal/web/handlers/giveaway.go
- `~` services/portal/internal/web/handlers/handlers.go
- `~` services/portal/internal/web/handlers/middleware.go
- `~` services/portal/internal/web/templates/about.html
- `+` services/portal/internal/web/templates/admin_giveaway.html
- `+` services/portal/internal/web/templates/admin_giveaway_edit.html
- `~` services/portal/internal/web/templates/base.html
- `~` services/portal/internal/web/templates/dashboard.html
- `+` services/portal/internal/web/templates/giveaway.html
- `+` services/portal/internal/web/templates/giveaway_item.html
- `~` services/portal/internal/web/templates/home.html
- `~` services/portal/internal/web/templates/login.html
- `~` services/portal/internal/web/templates/partials/footer.html
- `~` services/portal/internal/web/templates/partials/navbar.html
- `~` services/portal/internal/web/templates/signup.html
- `+` services/portal/pkg/fees/fees.go
- `+` services/portal/pkg/fees/fees_test.go
- `+` services/portal/pkg/models/giveaway.go
- `~` services/portal/pkg/models/models.go
- `+` services/portal/tests/integration/admin_test.go
- `~` services/portal/tests/integration/signup_test.go

---

*Auto-generated from workstream: workstream_9d893d36-0d7c-41ea-907c-d1ed3c6cc0c3*
