### PR TITLE
Migrate magic bar command palette backend from omnisaurus into portal

### DIFF
--- a/services/portal/cmd/server/main.go
+++ b/services/portal/cmd/server/main.go
@@ -111,6 +111,7 @@ func main() {
 	r.Route("/api", func(r chi.Router) {
 		r.Get("/items", h.APIListItems)
 		r.Get("/fee", h.APICalculateFee)
+		r.Get("/actions", h.SearchActions)
 		r.Post("/claims", h.APICreateClaim)
 	})
 

--- a/services/portal/internal/actions/registry.go
+++ b/services/portal/internal/actions/registry.go
@@ -1,0 +1,186 @@
+package actions
+
+import "strings"
+
+// ActionType categorizes what an action does when executed.
+type ActionType string
+
+const (
+	TypeNavigation ActionType = "navigation"
+	TypeFunction   ActionType = "function"
+)
+
+// Visibility controls when an action appears based on auth state.
+type Visibility int
+
+const (
+	VisibleAlways    Visibility = iota // Everyone sees it
+	VisibleLoggedOut                   // Only when not logged in
+	VisibleLoggedIn                    // Only when logged in
+	VisibleAdmin                       // Only admins
+)
+
+// Action represents a single executable action available in the magic bar.
+type Action struct {
+	ID          string     `json:"id"`
+	Type        ActionType `json:"type"`
+	Title       string     `json:"title"`
+	Description string     `json:"description"`
+	// For navigation actions: the URL to navigate to.
+	// For function actions: a client-side function identifier.
+	Target     string     `json:"target"`
+	Keywords   []string   `json:"keywords"`
+	Visibility Visibility `json:"-"` // Not serialized — server-side filtering only
+}
+
+// SearchContext provides auth state for filtering actions.
+type SearchContext struct {
+	LoggedIn bool
+	IsAdmin  bool
+}
+
+// Registry holds all available actions and supports filtered search.
+type Registry struct {
+	actions []Action
+}
+
+// New creates a Registry pre-populated with the default portal actions.
+func New() *Registry {
+	return &Registry{
+		actions: defaultActions(),
+	}
+}
+
+// Search returns actions matching the query that are visible given the context.
+// An empty query returns all visible actions. Matching is case-insensitive substring.
+func (r *Registry) Search(query string, ctx SearchContext) []Action {
+	q := strings.ToLower(strings.TrimSpace(query))
+	var results []Action
+
+	for _, a := range r.actions {
+		if !isVisible(a, ctx) {
+			continue
+		}
+		if q == "" || matchesQuery(a, q) {
+			results = append(results, a)
+		}
+	}
+	return results
+}
+
+func isVisible(a Action, ctx SearchContext) bool {
+	switch a.Visibility {
+	case VisibleAlways:
+		return true
+	case VisibleLoggedOut:
+		return !ctx.LoggedIn
+	case VisibleLoggedIn:
+		return ctx.LoggedIn
+	case VisibleAdmin:
+		return ctx.IsAdmin
+	default:
+		return true
+	}
+}
+
+func matchesQuery(a Action, q string) bool {
+	if strings.Contains(strings.ToLower(a.Title), q) {
+		return true
+	}
+	if strings.Contains(strings.ToLower(a.Description), q) {
+		return true
+	}
+	for _, kw := range a.Keywords {
+		if strings.Contains(strings.ToLower(kw), q) {
+			return true
+		}
+	}
+	return false
+}
+
+// defaultActions returns the built-in set of portal actions.
+func defaultActions() []Action {
+	return []Action{
+		// Public navigation — always visible
+		{
+			ID:          "nav-home",
+			Type:        TypeNavigation,
+			Title:       "Home",
+			Description: "Go to the home page",
+			Target:      "/",
+			Keywords:    []string{"home", "landing", "start", "main"},
+			Visibility:  VisibleAlways,
+		},
+		{
+			ID:          "nav-about",
+			Type:        TypeNavigation,
+			Title:       "About",
+			Description: "Learn about Hooper Works",
+			Target:      "/about",
+			Keywords:    []string{"about", "bio", "jared", "hooper", "info"},
+			Visibility:  VisibleAlways,
+		},
+		{
+			ID:          "nav-giveaway",
+			Type:        TypeNavigation,
+			Title:       "Free Stuff",
+			Description: "Browse free items available for pickup or delivery",
+			Target:      "/giveaway",
+			Keywords:    []string{"giveaway", "free", "stuff", "items", "pickup", "delivery", "claim"},
+			Visibility:  VisibleAlways,
+		},
+
+		// Auth pages — only when logged out
+		{
+			ID:          "nav-login",
+			Type:        TypeNavigation,
+			Title:       "Login",
+			Description: "Sign in to your account",
+			Target:      "/login",
+			Keywords:    []string{"login", "sign in", "signin", "account", "auth"},
+			Visibility:  VisibleLoggedOut,
+		},
+		{
+			ID:          "nav-signup",
+			Type:        TypeNavigation,
+			Title:       "Sign Up",
+			Description: "Create a new account",
+			Target:      "/signup",
+			Keywords:    []string{"signup", "sign up", "register", "create account", "new account"},
+			Visibility:  VisibleLoggedOut,
+		},
+
+		// Logged-in navigation
+		{
+			ID:          "nav-dashboard",
+			Type:        TypeNavigation,
+			Title:       "Dashboard",
+			Description: "View your account dashboard",
+			Target:      "/dashboard",
+			Keywords:    []string{"dashboard", "account", "profile", "settings", "sessions"},
+			Visibility:  VisibleLoggedIn,
+		},
+
+		// Admin navigation
+		{
+			ID:          "nav-admin-giveaway",
+			Type:        TypeNavigation,
+			Title:       "Manage Giveaways",
+			Description: "Admin panel for giveaway items and claims",
+			Target:      "/admin/giveaway",
+			Keywords:    []string{"admin", "manage", "giveaway", "items", "claims", "crud"},
+			Visibility:  VisibleAdmin,
+		},
+
+		// Function actions — logged in only
+		{
+			ID:          "fn-logout",
+			Type:        TypeFunction,
+			Title:       "Logout",
+			Description: "Sign out of your account",
+			Target:      "logout",
+			Keywords:    []string{"logout", "log out", "sign out", "signout", "exit"},
+			Visibility:  VisibleLoggedIn,
+		},
+	}
+}

--- a/services/portal/internal/actions/registry_test.go
+++ b/services/portal/internal/actions/registry_test.go
@@ -1,0 +1,215 @@
+package actions
+
+import (
+	"testing"
+)
+
+func TestNew_ReturnsNonEmptyRegistry(t *testing.T) {
+	reg := New()
+	results := reg.Search("", SearchContext{})
+	if len(results) == 0 {
+		t.Fatal("expected default actions, got none")
+	}
+}
+
+func TestSearch_EmptyQueryReturnsVisibleActions(t *testing.T) {
+	reg := New()
+
+	tests := []struct {
+		name     string
+		ctx      SearchContext
+		wantMin  int
+		wantMax  int
+		mustHave []string
+		mustNot  []string
+	}{
+		{
+			name:     "anonymous sees public + logged-out actions",
+			ctx:      SearchContext{},
+			mustHave: []string{"nav-home", "nav-about", "nav-giveaway", "nav-login", "nav-signup"},
+			mustNot:  []string{"nav-dashboard", "nav-admin-giveaway", "fn-logout"},
+		},
+		{
+			name:     "logged-in user sees public + logged-in actions",
+			ctx:      SearchContext{LoggedIn: true},
+			mustHave: []string{"nav-home", "nav-about", "nav-giveaway", "nav-dashboard", "fn-logout"},
+			mustNot:  []string{"nav-login", "nav-signup", "nav-admin-giveaway"},
+		},
+		{
+			name:     "admin sees public + logged-in + admin actions",
+			ctx:      SearchContext{LoggedIn: true, IsAdmin: true},
+			mustHave: []string{"nav-home", "nav-about", "nav-giveaway", "nav-dashboard", "nav-admin-giveaway", "fn-logout"},
+			mustNot:  []string{"nav-login", "nav-signup"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			results := reg.Search("", tt.ctx)
+			ids := make(map[string]bool)
+			for _, a := range results {
+				ids[a.ID] = true
+			}
+
+			for _, id := range tt.mustHave {
+				if !ids[id] {
+					t.Errorf("expected action %q in results, but not found", id)
+				}
+			}
+			for _, id := range tt.mustNot {
+				if ids[id] {
+					t.Errorf("action %q should not be in results for context %+v", id, tt.ctx)
+				}
+			}
+		})
+	}
+}
+
+func TestSearch_QueryFiltering(t *testing.T) {
+	reg := New()
+
+	tests := []struct {
+		name    string
+		query   string
+		ctx     SearchContext
+		wantIDs []string
+	}{
+		{
+			name:    "search for home",
+			query:   "home",
+			ctx:     SearchContext{},
+			wantIDs: []string{"nav-home"},
+		},
+		{
+			name:    "search for giveaway matches free stuff",
+			query:   "giveaway",
+			ctx:     SearchContext{},
+			wantIDs: []string{"nav-giveaway"},
+		},
+		{
+			name:    "search for free matches giveaway via keywords",
+			query:   "free",
+			ctx:     SearchContext{},
+			wantIDs: []string{"nav-giveaway"},
+		},
+		{
+			name:    "case insensitive search",
+			query:   "HOME",
+			ctx:     SearchContext{},
+			wantIDs: []string{"nav-home"},
+		},
+		{
+			name:    "search for logout when logged in",
+			query:   "logout",
+			ctx:     SearchContext{LoggedIn: true},
+			wantIDs: []string{"fn-logout"},
+		},
+		{
+			name:    "search for logout when logged out returns nothing",
+			query:   "logout",
+			ctx:     SearchContext{},
+			wantIDs: []string{},
+		},
+		{
+			name:    "search for admin when not admin returns nothing",
+			query:   "admin",
+			ctx:     SearchContext{LoggedIn: true},
+			wantIDs: []string{},
+		},
+		{
+			name:    "search for admin when admin returns manage giveaways",
+			query:   "admin",
+			ctx:     SearchContext{LoggedIn: true, IsAdmin: true},
+			wantIDs: []string{"nav-admin-giveaway"},
+		},
+		{
+			name:    "no match returns empty",
+			query:   "xyznonexistent",
+			ctx:     SearchContext{},
+			wantIDs: []string{},
+		},
+		{
+			name:    "whitespace-only query returns all visible",
+			query:   "   ",
+			ctx:     SearchContext{},
+			wantIDs: []string{"nav-home", "nav-about", "nav-giveaway", "nav-login", "nav-signup"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			results := reg.Search(tt.query, tt.ctx)
+			ids := make(map[string]bool)
+			for _, a := range results {
+				ids[a.ID] = true
+			}
+
+			if len(tt.wantIDs) == 0 && len(results) != 0 {
+				t.Errorf("expected no results, got %d: %v", len(results), resultIDs(results))
+				return
+			}
+
+			for _, id := range tt.wantIDs {
+				if !ids[id] {
+					t.Errorf("expected action %q in results, got %v", id, resultIDs(results))
+				}
+			}
+
+			if len(tt.wantIDs) > 0 && len(results) != len(tt.wantIDs) {
+				// Only check exact count when we have specific expected IDs (not the whitespace test)
+				if tt.query != "   " {
+					t.Errorf("expected %d results, got %d: %v", len(tt.wantIDs), len(results), resultIDs(results))
+				}
+			}
+		})
+	}
+}
+
+func TestSearch_ActionFields(t *testing.T) {
+	reg := New()
+	results := reg.Search("home", SearchContext{})
+	if len(results) == 0 {
+		t.Fatal("expected at least one result for 'home'")
+	}
+
+	home := results[0]
+	if home.ID != "nav-home" {
+		t.Errorf("id = %q, want nav-home", home.ID)
+	}
+	if home.Type != TypeNavigation {
+		t.Errorf("type = %q, want navigation", home.Type)
+	}
+	if home.Title != "Home" {
+		t.Errorf("title = %q, want Home", home.Title)
+	}
+	if home.Target != "/" {
+		t.Errorf("target = %q, want /", home.Target)
+	}
+	if len(home.Keywords) == 0 {
+		t.Error("expected non-empty keywords")
+	}
+}
+
+func TestSearch_FunctionActionType(t *testing.T) {
+	reg := New()
+	results := reg.Search("logout", SearchContext{LoggedIn: true})
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result for 'logout', got %d", len(results))
+	}
+
+	logout := results[0]
+	if logout.Type != TypeFunction {
+		t.Errorf("type = %q, want function", logout.Type)
+	}
+	if logout.Target != "logout" {
+		t.Errorf("target = %q, want logout", logout.Target)
+	}
+}
+
+func resultIDs(actions []Action) []string {
+	ids := make([]string, len(actions))
+	for i, a := range actions {
+		ids[i] = a.ID
+	}
+	return ids
+}

--- a/services/portal/tests/integration/actions_test.go
+++ b/services/portal/tests/integration/actions_test.go
@@ -1,0 +1,287 @@
+package integration
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/cookiejar"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/jredh-dev/nexus/services/portal/config"
+	"github.com/jredh-dev/nexus/services/portal/internal/auth"
+	"github.com/jredh-dev/nexus/services/portal/internal/database"
+	"github.com/jredh-dev/nexus/services/portal/internal/web/handlers"
+	"github.com/jredh-dev/nexus/services/portal/pkg/models"
+)
+
+// testServerWithActions sets up a test server that includes the /api/actions route.
+func testServerWithActions(t *testing.T) (srv *httptest.Server, client *http.Client, db *database.DB, authSvc *auth.Service, cleanup func()) {
+	t.Helper()
+
+	root := findMonorepoRoot(t)
+	origDir, _ := os.Getwd()
+	if err := os.Chdir(root); err != nil {
+		t.Fatalf("chdir to monorepo root: %v", err)
+	}
+
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	giveawayDBPath := filepath.Join(dir, "giveaway_test.db")
+
+	var err error
+	db, err = database.New(dbPath)
+	if err != nil {
+		t.Fatalf("open test db: %v", err)
+	}
+
+	giveawayDB, err := database.NewGiveaway(giveawayDBPath)
+	if err != nil {
+		t.Fatalf("open giveaway test db: %v", err)
+	}
+
+	cfg := &config.Config{
+		Server:   config.ServerConfig{Port: "0", Env: "test"},
+		DB:       config.DBConfig{Path: dbPath},
+		Giveaway: config.GiveawayConfig{DBPath: giveawayDBPath},
+		Session:  config.SessionConfig{Secret: "test-secret", MaxAge: 3600},
+	}
+
+	authSvc = auth.New(db, cfg)
+	h := handlers.New(db, giveawayDB, cfg, authSvc)
+
+	r := chi.NewRouter()
+	r.Get("/", h.Home)
+	r.Get("/login", h.LoginPage)
+	r.Post("/login", h.Login)
+	r.Get("/signup", h.SignupPage)
+	r.Post("/signup", h.Signup)
+	r.Get("/logout", h.Logout)
+	r.Get("/api/actions", h.SearchActions)
+	r.Group(func(r chi.Router) {
+		r.Use(handlers.AuthMiddleware(authSvc))
+		r.Get("/dashboard", h.Dashboard)
+	})
+
+	srv = httptest.NewServer(r)
+
+	jar, _ := cookiejar.New(nil)
+	client = &http.Client{
+		Jar: jar,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			if len(via) >= 10 {
+				return http.ErrUseLastResponse
+			}
+			return nil
+		},
+	}
+
+	cleanup = func() {
+		srv.Close()
+		db.Close()
+		giveawayDB.Close()
+		_ = os.Chdir(origDir)
+	}
+
+	return srv, client, db, authSvc, cleanup
+}
+
+// actionResult is a minimal struct for deserializing API responses.
+type actionResult struct {
+	ID          string `json:"id"`
+	Type        string `json:"type"`
+	Title       string `json:"title"`
+	Description string `json:"description"`
+	Target      string `json:"target"`
+}
+
+func getActions(t *testing.T, client *http.Client, srvURL, query string) []actionResult {
+	t.Helper()
+	resp, err := client.Get(srvURL + "/api/actions?q=" + url.QueryEscape(query))
+	if err != nil {
+		t.Fatalf("GET /api/actions: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET /api/actions status = %d, want 200", resp.StatusCode)
+	}
+
+	ct := resp.Header.Get("Content-Type")
+	if ct != "application/json" {
+		t.Fatalf("Content-Type = %q, want application/json", ct)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+
+	var results []actionResult
+	if err := json.Unmarshal(body, &results); err != nil {
+		t.Fatalf("unmarshal actions: %v (body: %s)", err, string(body))
+	}
+	return results
+}
+
+func actionIDs(results []actionResult) map[string]bool {
+	ids := make(map[string]bool)
+	for _, r := range results {
+		ids[r.ID] = true
+	}
+	return ids
+}
+
+func TestSearchActions_AnonymousEmptyQuery(t *testing.T) {
+	srv, client, _, _, cleanup := testServerWithActions(t)
+	defer cleanup()
+
+	results := getActions(t, client, srv.URL, "")
+	ids := actionIDs(results)
+
+	// Anonymous user should see public + logged-out actions.
+	for _, want := range []string{"nav-home", "nav-about", "nav-giveaway", "nav-login", "nav-signup"} {
+		if !ids[want] {
+			t.Errorf("expected action %q for anonymous user, not found", want)
+		}
+	}
+	for _, notWant := range []string{"nav-dashboard", "nav-admin-giveaway", "fn-logout"} {
+		if ids[notWant] {
+			t.Errorf("action %q should not be visible to anonymous user", notWant)
+		}
+	}
+}
+
+func TestSearchActions_AnonymousWithQuery(t *testing.T) {
+	srv, client, _, _, cleanup := testServerWithActions(t)
+	defer cleanup()
+
+	results := getActions(t, client, srv.URL, "home")
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result for 'home', got %d", len(results))
+	}
+	if results[0].ID != "nav-home" {
+		t.Errorf("result id = %q, want nav-home", results[0].ID)
+	}
+}
+
+func TestSearchActions_LoggedInUser(t *testing.T) {
+	srv, client, _, _, cleanup := testServerWithActions(t)
+	defer cleanup()
+
+	// Sign up and log in.
+	signupAndLogin(t, client, srv.URL, "actionsuser", "actions@example.com", "5559999999", "password", "Actions User")
+
+	results := getActions(t, client, srv.URL, "")
+	ids := actionIDs(results)
+
+	// Logged-in user should see public + logged-in actions, NOT logged-out actions.
+	for _, want := range []string{"nav-home", "nav-about", "nav-giveaway", "nav-dashboard", "fn-logout"} {
+		if !ids[want] {
+			t.Errorf("expected action %q for logged-in user, not found", want)
+		}
+	}
+	for _, notWant := range []string{"nav-login", "nav-signup", "nav-admin-giveaway"} {
+		if ids[notWant] {
+			t.Errorf("action %q should not be visible to non-admin logged-in user", notWant)
+		}
+	}
+}
+
+func TestSearchActions_AdminUser(t *testing.T) {
+	srv, client, db, _, cleanup := testServerWithActions(t)
+	defer cleanup()
+
+	// Create user, promote to admin, re-login.
+	signupAndLogin(t, client, srv.URL, "adminactions", "adminactions@example.com", "5558888888", "password", "Admin Actions")
+
+	user, err := db.GetUserByEmail("adminactions@example.com")
+	if err != nil || user == nil {
+		t.Fatalf("lookup user: %v", err)
+	}
+	if err := db.UpdateUserRole(user.ID, models.RoleAdmin); err != nil {
+		t.Fatalf("promote to admin: %v", err)
+	}
+
+	// Logout and re-login so session picks up admin role.
+	resp, err := client.Get(srv.URL + "/logout")
+	if err != nil {
+		t.Fatalf("logout: %v", err)
+	}
+	resp.Body.Close()
+
+	resp, err = postForm(client, srv.URL+"/login", url.Values{
+		"email":    {"adminactions@example.com"},
+		"password": {"password"},
+	})
+	if err != nil {
+		t.Fatalf("login: %v", err)
+	}
+	resp.Body.Close()
+
+	results := getActions(t, client, srv.URL, "")
+	ids := actionIDs(results)
+
+	// Admin should see everything except logged-out actions.
+	for _, want := range []string{"nav-home", "nav-about", "nav-giveaway", "nav-dashboard", "nav-admin-giveaway", "fn-logout"} {
+		if !ids[want] {
+			t.Errorf("expected action %q for admin user, not found", want)
+		}
+	}
+	for _, notWant := range []string{"nav-login", "nav-signup"} {
+		if ids[notWant] {
+			t.Errorf("action %q should not be visible to logged-in admin", notWant)
+		}
+	}
+}
+
+func TestSearchActions_LogoutHiddenForAnonymous(t *testing.T) {
+	srv, client, _, _, cleanup := testServerWithActions(t)
+	defer cleanup()
+
+	results := getActions(t, client, srv.URL, "logout")
+	if len(results) != 0 {
+		t.Errorf("anonymous search for 'logout': expected 0 results, got %d", len(results))
+	}
+}
+
+func TestSearchActions_NoMatch(t *testing.T) {
+	srv, client, _, _, cleanup := testServerWithActions(t)
+	defer cleanup()
+
+	results := getActions(t, client, srv.URL, "xyznonexistent123")
+	if len(results) != 0 {
+		t.Errorf("expected 0 results for nonsense query, got %d", len(results))
+	}
+}
+
+func TestSearchActions_ResponseFormat(t *testing.T) {
+	srv, client, _, _, cleanup := testServerWithActions(t)
+	defer cleanup()
+
+	results := getActions(t, client, srv.URL, "about")
+	if len(results) == 0 {
+		t.Fatal("expected at least one result for 'about'")
+	}
+
+	r := results[0]
+	if r.ID == "" {
+		t.Error("action id is empty")
+	}
+	if r.Type == "" {
+		t.Error("action type is empty")
+	}
+	if r.Title == "" {
+		t.Error("action title is empty")
+	}
+	if r.Description == "" {
+		t.Error("action description is empty")
+	}
+	if r.Target == "" {
+		t.Error("action target is empty")
+	}
+}


### PR DESCRIPTION
## Summary

Migrate magic bar command palette backend from omnisaurus into portal

## Changes

- **Commits**: 6 (will be squashed)
- **Changes**: 33 files changed, 3953 insertions(+), 247 deletions(-)

## Files Changed

- `~` contact.yaml
- `~` services/portal/cmd/server/main.go
- `~` services/portal/config/config.go
- `+` services/portal/internal/actions/registry.go
- `+` services/portal/internal/actions/registry_test.go
- `~` services/portal/internal/auth/errors.go
- `~` services/portal/internal/auth/service.go
- `~` services/portal/internal/database/database.go
- `+` services/portal/internal/database/giveaway.go
- `+` services/portal/internal/database/giveaway_test.go
- `+` services/portal/internal/web/handlers/admin.go
- `+` services/portal/internal/web/handlers/giveaway.go
- `~` services/portal/internal/web/handlers/handlers.go
- `~` services/portal/internal/web/handlers/middleware.go
- `~` services/portal/internal/web/templates/about.html
- `+` services/portal/internal/web/templates/admin_giveaway.html
- `+` services/portal/internal/web/templates/admin_giveaway_edit.html
- `~` services/portal/internal/web/templates/base.html
- `~` services/portal/internal/web/templates/dashboard.html
- `+` services/portal/internal/web/templates/giveaway.html
- `+` services/portal/internal/web/templates/giveaway_item.html
- `~` services/portal/internal/web/templates/home.html
- `~` services/portal/internal/web/templates/login.html
- `~` services/portal/internal/web/templates/partials/footer.html
- `~` services/portal/internal/web/templates/partials/navbar.html
- `~` services/portal/internal/web/templates/signup.html
- `+` services/portal/pkg/fees/fees.go
- `+` services/portal/pkg/fees/fees_test.go
- `+` services/portal/pkg/models/giveaway.go
- `~` services/portal/pkg/models/models.go
- `+` services/portal/tests/integration/actions_test.go
- `+` services/portal/tests/integration/admin_test.go
- `~` services/portal/tests/integration/signup_test.go

---

*Auto-generated from workstream: workstream_f0a53c09-a899-4469-a336-316fa0309d2b*
