### PR TITLE
Add web frontend Cloud Run deployment config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,28 @@ jobs:
       - name: Build cal server
         run: CGO_ENABLED=1 go build -v ./services/cal/cmd/server
 
+  build-web:
+    name: Build Web Frontend
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: services/web/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: services/web
+
+      - name: Build
+        run: npm run build
+        working-directory: services/web
+
   test:
     name: Test
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-web-dev.yml
+++ b/.github/workflows/deploy-web-dev.yml
@@ -1,0 +1,103 @@
+name: Deploy Web Frontend to Cloud Run (DEV)
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'services/web/**'
+  workflow_dispatch:
+
+env:
+  GCP_PROJECT_ID: dea-noctua
+  GCP_REGION: us-central1
+  SERVICE_NAME: nexus-web-dev
+  IMAGE_NAME: gcr.io/dea-noctua/nexus-web-dev
+  PORTAL_URL: https://nexus-portal-dev-2tvic4xjjq-uc.a.run.app
+
+jobs:
+  deploy:
+    name: Build and Deploy Web Frontend to Cloud Run DEV
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set version variables
+        id: version
+        run: |
+          VERSION="v0.0.1.$(git rev-list --count HEAD)"
+          COMMIT=$(git rev-parse --short HEAD)
+          BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+          echo "COMMIT=$COMMIT" >> $GITHUB_OUTPUT
+          echo "BUILD_DATE=$BUILD_DATE" >> $GITHUB_OUTPUT
+          echo "Building version: $VERSION (commit: $COMMIT)"
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.WIF_PROVIDER }}
+          service_account: ${{ secrets.WIF_SERVICE_ACCOUNT }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Configure Docker for GCR
+        run: gcloud auth configure-docker
+
+      - name: Build Docker image
+        run: |
+          docker build \
+            -f services/web/Dockerfile \
+            -t ${{ env.IMAGE_NAME }}:${{ steps.version.outputs.VERSION }} \
+            -t ${{ env.IMAGE_NAME }}:latest \
+            .
+
+      - name: Push Docker image to GCR
+        run: |
+          docker push ${{ env.IMAGE_NAME }}:${{ steps.version.outputs.VERSION }}
+          docker push ${{ env.IMAGE_NAME }}:latest
+
+      - name: Deploy to Cloud Run
+        run: |
+          VERSION_LABEL=$(echo "${{ steps.version.outputs.VERSION }}" | tr '.' '-')
+          gcloud run deploy ${{ env.SERVICE_NAME }} \
+            --image ${{ env.IMAGE_NAME }}:${{ steps.version.outputs.VERSION }} \
+            --region ${{ env.GCP_REGION }} \
+            --platform managed \
+            --allow-unauthenticated \
+            --port 8080 \
+            --memory 256Mi \
+            --cpu 1 \
+            --min-instances 0 \
+            --max-instances 5 \
+            --set-env-vars "ENVIRONMENT=dev,PORTAL_URL=${{ env.PORTAL_URL }},HOST=0.0.0.0,PORT=8080" \
+            --service-account ${{ secrets.WIF_SERVICE_ACCOUNT }} \
+            --labels "environment=dev,app=nexus-web,version=$VERSION_LABEL"
+
+      - name: Get service URL
+        id: service-url
+        run: |
+          SERVICE_URL=$(gcloud run services describe ${{ env.SERVICE_NAME }} \
+            --region ${{ env.GCP_REGION }} \
+            --format 'value(status.url)')
+          echo "url=$SERVICE_URL" >> $GITHUB_OUTPUT
+          echo "Service deployed to: $SERVICE_URL"
+
+      - name: Summary
+        run: |
+          echo "## Deployment Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- **Environment**: DEV" >> $GITHUB_STEP_SUMMARY
+          echo "- **Version**: ${{ steps.version.outputs.VERSION }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Commit**: ${{ steps.version.outputs.COMMIT }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Service URL**: ${{ steps.service-url.outputs.url }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Image**: ${{ env.IMAGE_NAME }}:${{ steps.version.outputs.VERSION }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Portal Backend**: ${{ env.PORTAL_URL }}" >> $GITHUB_STEP_SUMMARY

--- a/services/web/Dockerfile
+++ b/services/web/Dockerfile
@@ -1,19 +1,42 @@
+# Build stage
+# Build context is the repo root (docker build -f services/web/Dockerfile .)
 FROM node:22-alpine AS build
 
 WORKDIR /app
-COPY package.json package-lock.json* ./
-RUN npm ci
-COPY . .
-RUN npm run build
 
+# Copy only web service package files first for layer caching
+COPY services/web/package.json services/web/package-lock.json* ./services/web/
+RUN cd services/web && npm ci
+
+# Copy the web service source
+COPY services/web/ ./services/web/
+
+# Build-time env: PUBLIC_API_URL stays as '/' since we proxy through SSR middleware
+ARG PUBLIC_API_URL=/
+ENV PUBLIC_API_URL=${PUBLIC_API_URL}
+
+RUN cd services/web && npm run build
+
+# Runtime stage
 FROM node:22-alpine AS runtime
 
 WORKDIR /app
-COPY --from=build /app/dist ./dist
-COPY --from=build /app/node_modules ./node_modules
+
+COPY --from=build /app/services/web/dist ./dist
+COPY --from=build /app/services/web/node_modules ./node_modules
+
+RUN chown -R node:node /app
+
+USER node
 
 ENV HOST=0.0.0.0
-ENV PORT=3000
+ENV PORT=8080
+# Portal backend URL for SSR proxy (service-to-service within Cloud Run)
+ENV PORTAL_URL=http://localhost:8080
 
-EXPOSE 3000
+EXPOSE 8080
+
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+    CMD wget --no-verbose --tries=1 --spider http://localhost:8080/ || exit 1
+
 CMD ["node", "dist/server/entry.mjs"]

--- a/services/web/src/middleware.ts
+++ b/services/web/src/middleware.ts
@@ -1,0 +1,37 @@
+import { defineMiddleware } from 'astro:middleware';
+
+// Proxy Connect RPC calls to the portal backend.
+// In production, PORTAL_URL points to the portal Cloud Run service.
+// This avoids CORS issues — browser calls same-origin '/', SSR proxies to portal.
+const portalUrl = import.meta.env.PORTAL_URL || process.env.PORTAL_URL || 'http://localhost:8080';
+
+export const onRequest = defineMiddleware(async (context, next) => {
+  const { pathname } = context.url;
+
+  // Proxy Connect RPC and legacy API calls to portal
+  if (pathname.startsWith('/portal.v1.') || pathname.startsWith('/api/')) {
+    const target = new URL(pathname + context.url.search, portalUrl);
+
+    const headers = new Headers(context.request.headers);
+    // Remove host header so it doesn't confuse the upstream
+    headers.delete('host');
+
+    const resp = await fetch(target.toString(), {
+      method: context.request.method,
+      headers,
+      body: context.request.method !== 'GET' && context.request.method !== 'HEAD'
+        ? context.request.body
+        : undefined,
+      // @ts-expect-error — Node fetch supports duplex for streaming bodies
+      duplex: 'half',
+    });
+
+    return new Response(resp.body, {
+      status: resp.status,
+      statusText: resp.statusText,
+      headers: resp.headers,
+    });
+  }
+
+  return next();
+});

--- a/services/web/terraform/environments/dev/backend.tf
+++ b/services/web/terraform/environments/dev/backend.tf
@@ -1,0 +1,8 @@
+# Terraform Backend Configuration
+
+terraform {
+  backend "gcs" {
+    bucket = "dea-noctua-terraform-state"
+    prefix = "nexus/web/dev"
+  }
+}

--- a/services/web/terraform/environments/dev/main.tf
+++ b/services/web/terraform/environments/dev/main.tf
@@ -1,0 +1,61 @@
+# Nexus Web Frontend - Development Environment
+
+terraform {
+  required_version = ">= 1.6.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}
+
+locals {
+  environment  = "dev"
+  service_name = "nexus-web-${local.environment}"
+  github_org   = "jredh-dev"
+  github_repo  = "nexus"
+
+  common_labels = {
+    app         = "nexus-web"
+    environment = local.environment
+    managed_by  = "terraform"
+  }
+}
+
+# Reuse portal's IAM module — same WIF setup, same service account
+# The web frontend shares the GitHub Actions service account with portal
+# since they're in the same repo and use the same WIF pool.
+
+# Module: Cloud Run
+module "cloud_run" {
+  source                = "../../../portal/terraform/modules/cloud-run"
+  project_id            = var.project_id
+  region                = var.region
+  service_name          = local.service_name
+  image                 = var.cloud_run_image
+  service_account_email = var.service_account_email
+
+  environment_variables = {
+    ENVIRONMENT = local.environment
+    PORTAL_URL  = var.portal_url
+    HOST        = "0.0.0.0"
+    PORT        = "8080"
+  }
+
+  secrets = {}
+
+  memory                = "256Mi"
+  cpu                   = "1"
+  min_instances         = 0
+  max_instances         = 5
+  allow_unauthenticated = true
+
+  labels = local.common_labels
+}

--- a/services/web/terraform/environments/dev/outputs.tf
+++ b/services/web/terraform/environments/dev/outputs.tf
@@ -1,0 +1,32 @@
+# Development Environment Outputs
+
+output "project_id" {
+  description = "GCP Project ID"
+  value       = var.project_id
+}
+
+output "region" {
+  description = "GCP region"
+  value       = var.region
+}
+
+output "service_url" {
+  description = "Cloud Run service URL (DEV environment)"
+  value       = module.cloud_run.service_url
+}
+
+output "service_name" {
+  description = "Cloud Run service name"
+  value       = module.cloud_run.service_name
+}
+
+output "deployment_summary" {
+  description = "Deployment summary"
+  value = {
+    environment = "dev"
+    service_url = module.cloud_run.service_url
+    project_id  = var.project_id
+    region      = var.region
+    portal_url  = var.portal_url
+  }
+}

--- a/services/web/terraform/environments/dev/variables.tf
+++ b/services/web/terraform/environments/dev/variables.tf
@@ -1,0 +1,30 @@
+# Development Environment Variables
+
+variable "project_id" {
+  description = "GCP Project ID"
+  type        = string
+  default     = "dea-noctua"
+}
+
+variable "region" {
+  description = "GCP region"
+  type        = string
+  default     = "us-central1"
+}
+
+variable "cloud_run_image" {
+  description = "Cloud Run container image URL"
+  type        = string
+  default     = "gcr.io/dea-noctua/nexus-web-dev:latest"
+}
+
+variable "service_account_email" {
+  description = "Service account email for Cloud Run (shared with portal)"
+  type        = string
+}
+
+variable "portal_url" {
+  description = "Portal backend URL for SSR proxy"
+  type        = string
+  default     = "https://nexus-portal-dev-2tvic4xjjq-uc.a.run.app"
+}


### PR DESCRIPTION
## Summary
- Updated Dockerfile: repo-root build context, port 8080 for Cloud Run, non-root `node` user
- Added SSR proxy middleware: forwards `/portal.v1.*` and `/api/` requests to portal backend (avoids CORS)
- Created `deploy-web-dev.yml` GitHub Actions workflow: builds Docker image, deploys to Cloud Run as `nexus-web-dev`
- Created terraform config (`services/web/terraform/`) reusing portal's cloud-run module
- Added `build-web` job to CI workflow (Node.js 22, npm ci + build)

## Architecture
```
Browser → Astro SSR (Cloud Run: nexus-web-dev:8080)
           ├── Static pages: rendered server-side
           ├── Preact islands: hydrated client-side
           └── /portal.v1.* → SSR middleware → Portal (Cloud Run: nexus-portal-dev:8080)
```

Portal URL set via `PORTAL_URL` env var at deploy time. `PUBLIC_API_URL` defaults to `/` (same-origin), so browser RPC calls go through the Astro SSR proxy — no CORS needed.