### PR TITLE
Fix web deploy: remove reserved PORT env var

### DIFF
--- a/.github/workflows/deploy-web-dev.yml
+++ b/.github/workflows/deploy-web-dev.yml
@@ -78,7 +78,7 @@ jobs:
             --cpu 1 \
             --min-instances 0 \
             --max-instances 5 \
-            --set-env-vars "ENVIRONMENT=dev,PORTAL_URL=${{ env.PORTAL_URL }},HOST=0.0.0.0,PORT=8080" \
+            --set-env-vars "ENVIRONMENT=dev,PORTAL_URL=${{ env.PORTAL_URL }},HOST=0.0.0.0" \
             --service-account ${{ secrets.WIF_SERVICE_ACCOUNT }} \
             --labels "environment=dev,app=nexus-web,version=$VERSION_LABEL"
 

--- a/services/web/terraform/environments/dev/main.tf
+++ b/services/web/terraform/environments/dev/main.tf
@@ -46,7 +46,6 @@ module "cloud_run" {
     ENVIRONMENT = local.environment
     PORTAL_URL  = var.portal_url
     HOST        = "0.0.0.0"
-    PORT        = "8080"
   }
 
   secrets = {}


### PR DESCRIPTION
## Summary
- Cloud Run reserves `PORT` env var — can't set it via `--set-env-vars`
- Removed `PORT=8080` from deploy workflow and terraform config
- Cloud Run injects `PORT=8080` automatically; Astro's node adapter reads it