### PR TITLE
Map portal.jredh.com to web frontend service

### DIFF
--- a/services/web/terraform/environments/dev/main.tf
+++ b/services/web/terraform/environments/dev/main.tf
@@ -57,4 +57,6 @@ module "cloud_run" {
   allow_unauthenticated = true
 
   labels = local.common_labels
+
+  custom_domain = var.custom_domain
 }

--- a/services/web/terraform/environments/dev/outputs.tf
+++ b/services/web/terraform/environments/dev/outputs.tf
@@ -23,10 +23,11 @@ output "service_name" {
 output "deployment_summary" {
   description = "Deployment summary"
   value = {
-    environment = "dev"
-    service_url = module.cloud_run.service_url
-    project_id  = var.project_id
-    region      = var.region
-    portal_url  = var.portal_url
+    environment   = "dev"
+    service_url   = module.cloud_run.service_url
+    custom_domain = module.cloud_run.custom_domain
+    project_id    = var.project_id
+    region        = var.region
+    portal_url    = var.portal_url
   }
 }

--- a/services/web/terraform/environments/dev/variables.tf
+++ b/services/web/terraform/environments/dev/variables.tf
@@ -28,3 +28,9 @@ variable "portal_url" {
   type        = string
   default     = "https://nexus-portal-dev-2tvic4xjjq-uc.a.run.app"
 }
+
+variable "custom_domain" {
+  description = "Custom domain for the web frontend"
+  type        = string
+  default     = "portal.jredh.com"
+}


### PR DESCRIPTION
## Summary
- Added `custom_domain` variable to shared cloud-run terraform module
- Added `google_cloud_run_domain_mapping` resource (conditional, only when domain provided)
- Web frontend terraform sets `custom_domain = "portal.jredh.com"`
- Domain mapping already remapped via CLI (`nexus-portal-dev` → `nexus-web-dev`); terraform codifies it

## What happened
- `portal.jredh.com` was a Cloud Run domain mapping pointing to `nexus-portal-dev` (Go SSR)
- Deleted that mapping, created new one pointing to `nexus-web-dev` (Astro SSR)
- DNS already had `CNAME ghs.googlehosted.com` — no DNS changes needed
- Cert provisioning in progress (same domain, should be quick)

## Architecture
```
portal.jredh.com → Cloud Run domain mapping → nexus-web-dev (Astro SSR)
                                                └── /portal.v1.* → middleware → nexus-portal-dev (Go API)
```