### PR TITLE
Fix portal proxy env var, add Playwright e2e login test

### DIFF
--- a/services/web/.gitignore
+++ b/services/web/.gitignore
@@ -22,3 +22,7 @@ pnpm-debug.log*
 
 # jetbrains setting folder
 .idea/
+
+# playwright
+test-results/
+playwright-report/

--- a/services/web/package-lock.json
+++ b/services/web/package-lock.json
@@ -16,6 +16,9 @@
         "astro": "^5.17.1",
         "bulma": "^1.0.4",
         "preact": "^10.28.4"
+      },
+      "devDependencies": {
+        "@playwright/test": "^1.58.2"
       }
     },
     "node_modules/@astrojs/compiler": {
@@ -1421,6 +1424,22 @@
       "resolved": "https://registry.npmjs.org/@oslojs/encoding/-/encoding-1.1.0.tgz",
       "integrity": "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==",
       "license": "MIT"
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@preact/preset-vite": {
       "version": "2.10.3",
@@ -4579,6 +4598,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/services/web/package.json
+++ b/services/web/package.json
@@ -7,7 +7,8 @@
     "build": "astro build",
     "preview": "astro preview",
     "astro": "astro",
-    "test:smoke": "node --test tests/smoke.mjs"
+    "test:smoke": "node --test tests/smoke.mjs",
+    "test:e2e": "npx playwright test"
   },
   "dependencies": {
     "@astrojs/node": "^9.5.4",
@@ -18,5 +19,8 @@
     "astro": "^5.17.1",
     "bulma": "^1.0.4",
     "preact": "^10.28.4"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.58.2"
   }
 }

--- a/services/web/playwright.config.ts
+++ b/services/web/playwright.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig } from '@playwright/test';
+
+// Run against deployed portal.jredh.com by default, or a local URL via BASE_URL.
+const baseURL = process.env.BASE_URL || 'https://portal.jredh.com';
+
+export default defineConfig({
+  testDir: 'tests',
+  testMatch: '**/*.e2e.ts',
+  timeout: 30_000,
+  retries: 0,
+  use: {
+    baseURL,
+    // Don't follow redirects automatically — we want to assert on them.
+    headless: true,
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { browserName: 'chromium' },
+    },
+  ],
+});

--- a/services/web/src/lib/proxy.ts
+++ b/services/web/src/lib/proxy.ts
@@ -1,0 +1,36 @@
+// Proxy helper for forwarding requests to the portal backend.
+// Shared by middleware.ts and page POST handlers.
+
+// Resolve portal backend URL at runtime only — import.meta.env is inlined
+// at build time and will be undefined for non-PUBLIC_ variables.
+export function getPortalUrl(): string {
+  return process.env.PORTAL_URL || 'http://localhost:8080';
+}
+
+// Proxy a request to the portal backend, preserving headers (except Host).
+export async function proxyToPortal(
+  request: Request,
+  pathAndSearch: string,
+): Promise<Response> {
+  const target = new URL(pathAndSearch, getPortalUrl());
+
+  const headers = new Headers(request.headers);
+  headers.delete('host');
+
+  const resp = await fetch(target.toString(), {
+    method: request.method,
+    headers,
+    body: request.method !== 'GET' && request.method !== 'HEAD'
+      ? request.body
+      : undefined,
+    // @ts-expect-error — Node fetch supports duplex for streaming bodies
+    duplex: 'half',
+    redirect: 'manual',
+  });
+
+  return new Response(resp.body, {
+    status: resp.status,
+    statusText: resp.statusText,
+    headers: resp.headers,
+  });
+}

--- a/services/web/src/pages/dashboard.astro
+++ b/services/web/src/pages/dashboard.astro
@@ -4,6 +4,7 @@ import Topbar from '../components/Topbar.astro';
 import { createConnectTransport } from '@connectrpc/connect-web';
 import { createClient } from '@connectrpc/connect';
 import { AuthService } from '../gen/portal/v1/auth_pb.js';
+import { getPortalUrl } from '../lib/proxy';
 
 // Redirect to login if no session cookie present.
 const sessionCookie = Astro.cookies.get('session');
@@ -13,7 +14,7 @@ if (!sessionCookie?.value) {
 
 // Call GetSession via Connect RPC, forwarding the session cookie.
 // In SSR, we talk directly to the portal backend (bypasses Astro middleware).
-const portalUrl = import.meta.env.PORTAL_URL || process.env.PORTAL_URL || 'http://localhost:8080';
+const portalUrl = getPortalUrl();
 
 const transport = createConnectTransport({
     baseUrl: portalUrl,

--- a/services/web/src/pages/login.astro
+++ b/services/web/src/pages/login.astro
@@ -2,30 +2,13 @@
 import Base from '../layouts/Base.astro';
 import Topbar from '../components/Topbar.astro';
 import type { APIContext } from 'astro';
+import { proxyToPortal } from '../lib/proxy';
 
 // Proxy POST /login to the portal backend.
 // Astro 5 requires an exported POST function to accept POST on a page route —
 // without it the Node adapter returns 405 before middleware fires.
 export async function POST(context: APIContext): Promise<Response> {
-  const portalUrl = import.meta.env.PORTAL_URL || process.env.PORTAL_URL || 'http://localhost:8080';
-  const target = new URL('/login', portalUrl);
-
-  const headers = new Headers(context.request.headers);
-  headers.delete('host');
-
-  const resp = await fetch(target.toString(), {
-    method: 'POST',
-    headers,
-    body: context.request.body,
-    // @ts-expect-error — Node fetch supports duplex
-    duplex: 'half',
-  });
-
-  return new Response(resp.body, {
-    status: resp.status,
-    statusText: resp.statusText,
-    headers: resp.headers,
-  });
+  return proxyToPortal(context.request, '/login');
 }
 
 const error = Astro.url.searchParams.get('error') || '';

--- a/services/web/src/pages/signup.astro
+++ b/services/web/src/pages/signup.astro
@@ -2,30 +2,13 @@
 import Base from '../layouts/Base.astro';
 import Topbar from '../components/Topbar.astro';
 import type { APIContext } from 'astro';
+import { proxyToPortal } from '../lib/proxy';
 
 // Proxy POST /signup to the portal backend.
 // Astro 5 requires an exported POST function to accept POST on a page route —
 // without it the Node adapter returns 405 before middleware fires.
 export async function POST(context: APIContext): Promise<Response> {
-  const portalUrl = import.meta.env.PORTAL_URL || process.env.PORTAL_URL || 'http://localhost:8080';
-  const target = new URL('/signup', portalUrl);
-
-  const headers = new Headers(context.request.headers);
-  headers.delete('host');
-
-  const resp = await fetch(target.toString(), {
-    method: 'POST',
-    headers,
-    body: context.request.body,
-    // @ts-expect-error — Node fetch supports duplex
-    duplex: 'half',
-  });
-
-  return new Response(resp.body, {
-    status: resp.status,
-    statusText: resp.statusText,
-    headers: resp.headers,
-  });
+  return proxyToPortal(context.request, '/signup');
 }
 
 const error = Astro.url.searchParams.get('error') || '';

--- a/services/web/tests/login.e2e.ts
+++ b/services/web/tests/login.e2e.ts
@@ -1,0 +1,86 @@
+import { test, expect } from '@playwright/test';
+
+// Full browser-driven login cycle test.
+// Uses the seeded demo account (demo@demo.com / demo).
+//
+// Run:
+//   BASE_URL=https://portal.jredh.com npx playwright test
+//   BASE_URL=http://localhost:4321 npx playwright test
+
+test.describe('Login cycle', () => {
+  test('shows login page', async ({ page }) => {
+    await page.goto('/login');
+    await expect(page.locator('h1')).toContainText('Welcome Back');
+    await expect(page.locator('form')).toBeVisible();
+  });
+
+  test('bad credentials show error on login page', async ({ page }) => {
+    await page.goto('/login');
+
+    await page.fill('input[name="email"]', 'nobody@example.com');
+    await page.fill('input[name="password"]', 'wrongpassword');
+    await page.click('button[type="submit"]');
+
+    // Should stay on /login with an error message.
+    await page.waitForURL(/\/login/);
+    await expect(page.locator('.notification.is-danger')).toBeVisible();
+    await expect(page.locator('.notification.is-danger')).toContainText('Invalid');
+  });
+
+  test('valid credentials redirect to dashboard with real data', async ({ page }) => {
+    await page.goto('/login');
+
+    await page.fill('input[name="email"]', 'demo@demo.com');
+    await page.fill('input[name="password"]', 'demo');
+    await page.click('button[type="submit"]');
+
+    // Should redirect to /dashboard.
+    await page.waitForURL(/\/dashboard/, { timeout: 15_000 });
+    await expect(page.locator('h1')).toContainText('Dashboard');
+
+    // Should show the demo user's profile data.
+    await expect(page.locator('text=demo@demo.com')).toBeVisible();
+
+    // Should have at least one active session.
+    await expect(page.locator('table')).toBeVisible();
+  });
+
+  test('logout redirects to home', async ({ page }) => {
+    // Login first.
+    await page.goto('/login');
+    await page.fill('input[name="email"]', 'demo@demo.com');
+    await page.fill('input[name="password"]', 'demo');
+    await page.click('button[type="submit"]');
+    await page.waitForURL(/\/dashboard/, { timeout: 15_000 });
+
+    // Click logout.
+    await page.click('a[href="/logout"]');
+
+    // Should redirect to /.
+    await page.waitForURL(/^\/$|\/$/);
+  });
+});
+
+test.describe('Signup page', () => {
+  test('shows signup page', async ({ page }) => {
+    await page.goto('/signup');
+    await expect(page.locator('h1')).toContainText('Create Account');
+    await expect(page.locator('form')).toBeVisible();
+  });
+
+  test('missing fields show error', async ({ page }) => {
+    await page.goto('/signup');
+
+    // Submit with only some fields filled (omit phone).
+    await page.fill('input[name="username"]', 'testuser_' + Date.now());
+    await page.fill('input[name="email"]', `testuser_${Date.now()}@example.com`);
+    await page.fill('input[name="password"]', 'password123');
+    // Leave phone empty — should fail.
+
+    await page.click('button[type="submit"]');
+
+    // Should stay on /signup with an error.
+    await page.waitForURL(/\/signup/);
+    await expect(page.locator('.notification.is-danger')).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary

Fix portal proxy env var, add Playwright e2e login test

## Changes

- **Commits**: 2 (will be squashed)
- **Changes**: 11 files changed, 348 insertions(+), 36 deletions(-)

## Files Changed

- `~` services/web/.gitignore
- `~` services/web/package-lock.json
- `~` services/web/package.json
- `+` services/web/playwright.config.ts
- `+` services/web/src/lib/proxy.ts
- `~` services/web/src/middleware.ts
- `~` services/web/src/pages/dashboard.astro
- `~` services/web/src/pages/login.astro
- `~` services/web/src/pages/signup.astro
- `+` services/web/tests/login.e2e.ts
- `+` services/web/tests/smoke.mjs

---

*Auto-generated from workstream: workstream_fix-portal-proxy-env-var-add-playwright-e2e-login-6e83a794*
