### PR TITLE
Fix login/signup POST: return proxy response from Astro frontmatter

### DIFF
--- a/services/web/src/lib/proxy.ts
+++ b/services/web/src/lib/proxy.ts
@@ -1,5 +1,5 @@
 // Proxy helper for forwarding requests to the portal backend.
-// Shared by middleware.ts and page POST handlers.
+// Shared by middleware.ts and page frontmatter POST handlers.
 
 // Resolve portal backend URL at runtime only — import.meta.env is inlined
 // at build time and will be undefined for non-PUBLIC_ variables.

--- a/services/web/src/pages/login.astro
+++ b/services/web/src/pages/login.astro
@@ -1,14 +1,20 @@
 ---
 import Base from '../layouts/Base.astro';
 import Topbar from '../components/Topbar.astro';
-import type { APIContext } from 'astro';
 import { proxyToPortal } from '../lib/proxy';
 
-// Proxy POST /login to the portal backend.
-// Astro 5 requires an exported POST function to accept POST on a page route —
-// without it the Node adapter returns 405 before middleware fires.
-export async function POST(context: APIContext): Promise<Response> {
-  return proxyToPortal(context.request, '/login');
+// Handle POST in frontmatter — returning a Response short-circuits the
+// template rendering, so the portal's 303 redirect reaches the browser.
+// The exported POST function below is still required: Astro 5's Node adapter
+// rejects POST on .astro pages that don't export POST (405 before middleware).
+if (Astro.request.method === 'POST') {
+  return proxyToPortal(Astro.request, '/login');
+}
+
+export function POST() {
+  // Never reached — frontmatter return above handles all POSTs.
+  // Exists solely to tell Astro this page accepts POST.
+  return new Response(null, { status: 204 });
 }
 
 const error = Astro.url.searchParams.get('error') || '';

--- a/services/web/src/pages/signup.astro
+++ b/services/web/src/pages/signup.astro
@@ -1,14 +1,18 @@
 ---
 import Base from '../layouts/Base.astro';
 import Topbar from '../components/Topbar.astro';
-import type { APIContext } from 'astro';
 import { proxyToPortal } from '../lib/proxy';
 
-// Proxy POST /signup to the portal backend.
-// Astro 5 requires an exported POST function to accept POST on a page route —
-// without it the Node adapter returns 405 before middleware fires.
-export async function POST(context: APIContext): Promise<Response> {
-  return proxyToPortal(context.request, '/signup');
+// Handle POST in frontmatter — returning a Response short-circuits the
+// template rendering, so the portal's 303 redirect reaches the browser.
+if (Astro.request.method === 'POST') {
+  return proxyToPortal(Astro.request, '/signup');
+}
+
+export function POST() {
+  // Never reached — frontmatter return above handles all POSTs.
+  // Exists solely to tell Astro this page accepts POST.
+  return new Response(null, { status: 204 });
 }
 
 const error = Astro.url.searchParams.get('error') || '';

--- a/services/web/tests/login.e2e.ts
+++ b/services/web/tests/login.e2e.ts
@@ -71,16 +71,17 @@ test.describe('Signup page', () => {
   test('missing fields show error', async ({ page }) => {
     await page.goto('/signup');
 
-    // Submit with only some fields filled (omit phone).
+    // Fill all required fields but use an invalid/duplicate email to trigger
+    // a server-side error from the portal backend.
     await page.fill('input[name="username"]', 'testuser_' + Date.now());
-    await page.fill('input[name="email"]', `testuser_${Date.now()}@example.com`);
+    await page.fill('input[name="email"]', 'demo@demo.com'); // duplicate
+    await page.fill('input[name="phone"]', '5551234567');
     await page.fill('input[name="password"]', 'password123');
-    // Leave phone empty — should fail.
 
     await page.click('button[type="submit"]');
 
-    // Should stay on /signup with an error.
-    await page.waitForURL(/\/signup/);
+    // Should redirect back to /signup with an error.
+    await page.waitForURL(/\/signup/, { timeout: 10_000 });
     await expect(page.locator('.notification.is-danger')).toBeVisible();
   });
 });


### PR DESCRIPTION
## Summary
- Astro `.astro` pages always render their template — the `POST` export only prevents 405 but the returned Response is ignored
- Move proxy call into frontmatter with early `return` to short-circuit template rendering
- Portal's 303 redirect now reaches the browser correctly
- Fix signup e2e test: use duplicate email (server-side error) instead of omitting required phone field

## Root cause
PR #40 added `POST` exports to `login.astro` and `signup.astro`, but Astro page components always render their HTML template. The `POST` function's `Response` was silently discarded. The fix is to check `Astro.request.method === 'POST'` in the frontmatter and `return proxyToPortal(...)` before the template.