### PR TITLE
Add rotating Wall of Lies to secrets service and web frontend

### DIFF
--- a/services/secrets/cmd/server/main.go
+++ b/services/secrets/cmd/server/main.go
@@ -85,6 +85,7 @@ func main() {
 		r.Get("/secrets", h.List)
 		r.Get("/secrets/{id}", h.Get)
 		r.Get("/stats", h.Stats)
+		r.Get("/lies", h.Lies)
 	})
 
 	addr := ":" + cfg.Port
@@ -102,6 +103,7 @@ func main() {
 		<-sigint
 
 		log.Println("Shutting down server...")
+		h.Stop()
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
 

--- a/services/secrets/internal/wall/wall.go
+++ b/services/secrets/internal/wall/wall.go
@@ -1,0 +1,107 @@
+// Package wall implements a rotating lies wall.
+//
+// A background worker periodically scans the store for lies and pre-builds
+// pages of up to PageSize lie values. Each HTTP request gets a different page
+// via an atomic round-robin counter, so consecutive visitors see different
+// content. When there are fewer lies than PageSize, every request returns
+// the same (only) page.
+package wall
+
+import (
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/jredh-dev/nexus/services/secrets/internal/store"
+)
+
+const (
+	// PageSize is the maximum number of lies per page.
+	PageSize = 1000
+
+	// RefreshInterval is how often the worker rebuilds pages.
+	RefreshInterval = 5 * time.Second
+)
+
+// Wall serves pre-built pages of lies in round-robin order.
+type Wall struct {
+	store   *store.Store
+	counter atomic.Uint64
+
+	mu    sync.RWMutex
+	pages []string // each entry is a text blob of up to PageSize lies
+	total int      // total number of lies across all pages
+	stop  chan struct{}
+}
+
+// New creates a new Wall and starts the background worker.
+func New(s *store.Store) *Wall {
+	w := &Wall{
+		store: s,
+		stop:  make(chan struct{}),
+	}
+	w.rebuild()
+	go w.run()
+	return w
+}
+
+// Page returns the next page of lies for the current request.
+// Returns the text blob and metadata (page index, total pages, total lies).
+func (w *Wall) Page() (text string, pageIdx int, totalPages int, totalLies int) {
+	w.mu.RLock()
+	defer w.mu.RUnlock()
+
+	if len(w.pages) == 0 {
+		return "", 0, 0, 0
+	}
+
+	idx := int(w.counter.Add(1)-1) % len(w.pages)
+	return w.pages[idx], idx, len(w.pages), w.total
+}
+
+// Stop shuts down the background worker.
+func (w *Wall) Stop() {
+	close(w.stop)
+}
+
+func (w *Wall) run() {
+	ticker := time.NewTicker(RefreshInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			w.rebuild()
+		case <-w.stop:
+			return
+		}
+	}
+}
+
+func (w *Wall) rebuild() {
+	all := w.store.List()
+
+	// Filter to lies only
+	lies := make([]string, 0, len(all))
+	for _, s := range all {
+		if s.State == store.Lie {
+			lies = append(lies, s.Value)
+		}
+	}
+
+	// Build pages
+	var pages []string
+	for i := 0; i < len(lies); i += PageSize {
+		end := i + PageSize
+		if end > len(lies) {
+			end = len(lies)
+		}
+		pages = append(pages, strings.Join(lies[i:end], "\n"))
+	}
+
+	w.mu.Lock()
+	w.pages = pages
+	w.total = len(lies)
+	w.mu.Unlock()
+}

--- a/services/secrets/internal/wall/wall_test.go
+++ b/services/secrets/internal/wall/wall_test.go
@@ -1,0 +1,111 @@
+package wall
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/jredh-dev/nexus/services/secrets/internal/store"
+)
+
+func TestWallEmpty(t *testing.T) {
+	s := store.New()
+	w := New(s)
+	defer w.Stop()
+
+	text, pageIdx, totalPages, totalLies := w.Page()
+	if text != "" || pageIdx != 0 || totalPages != 0 || totalLies != 0 {
+		t.Fatalf("expected empty wall, got text=%q page=%d/%d lies=%d", text, pageIdx, totalPages, totalLies)
+	}
+}
+
+func TestWallSinglePage(t *testing.T) {
+	s := store.New()
+
+	// Submit and betray some secrets
+	s.Submit("hello", "alice")
+	s.Submit("Hello", "bob") // casefold collision → "hello" becomes lie
+
+	s.Submit("racecar", "charlie") // palindrome self-betrayal
+
+	w := New(s)
+	defer w.Stop()
+
+	text, pageIdx, totalPages, totalLies := w.Page()
+	if totalLies != 2 {
+		t.Fatalf("expected 2 lies, got %d", totalLies)
+	}
+	if totalPages != 1 {
+		t.Fatalf("expected 1 page, got %d", totalPages)
+	}
+	if pageIdx != 0 {
+		t.Fatalf("expected page 0, got %d", pageIdx)
+	}
+	if text == "" {
+		t.Fatal("expected non-empty text")
+	}
+}
+
+func TestWallRoundRobin(t *testing.T) {
+	s := store.New()
+
+	// Create enough lies to span multiple pages.
+	// We need > PageSize lies. Each pair of submits creates 1 lie.
+	// Submit unique values, then betray them.
+	for i := 0; i < PageSize+500; i++ {
+		val := "secret-" + itoa(i)
+		s.Submit(val, "seeder")
+	}
+	// Betray them all — submit again with different case
+	for i := 0; i < PageSize+500; i++ {
+		val := "Secret-" + itoa(i) // CaseFold collision
+		s.Submit(val, "exposer")
+	}
+
+	w := New(s)
+	defer w.Stop()
+
+	_, _, totalPages, totalLies := w.Page()
+	if totalLies != PageSize+500 {
+		t.Fatalf("expected %d lies, got %d", PageSize+500, totalLies)
+	}
+	if totalPages != 2 {
+		t.Fatalf("expected 2 pages, got %d", totalPages)
+	}
+
+	// Round-robin: consecutive calls should alternate pages
+	_, p1, _, _ := w.Page()
+	_, p2, _, _ := w.Page()
+	if p1 == p2 {
+		t.Fatal("expected different pages on consecutive requests")
+	}
+}
+
+func TestWallTextContent(t *testing.T) {
+	s := store.New()
+
+	s.Submit("alpha", "user1")
+	s.Submit("Alpha", "user2") // exposes "alpha"
+
+	s.Submit("kayak", "user3") // palindrome self-betrayal
+
+	w := New(s)
+	defer w.Stop()
+
+	text, _, _, _ := w.Page()
+	lines := strings.Split(text, "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 lines, got %d: %v", len(lines), lines)
+	}
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var digits []byte
+	for n > 0 {
+		digits = append([]byte{byte('0' + n%10)}, digits...)
+		n /= 10
+	}
+	return string(digits)
+}

--- a/services/web/src/i18n/en.ts
+++ b/services/web/src/i18n/en.ts
@@ -12,6 +12,7 @@ const en = {
   'nav.dashboard': 'Dashboard',
   'nav.logout': 'Logout',
   'nav.contact': 'Contact',
+  'nav.lies': 'Lies',
 
   // MagicBar
   'magicbar.placeholder.hero': 'Where do you want to go?',
@@ -30,6 +31,7 @@ const en = {
   'magicbar.desc.dashboard': 'View your dashboard',
   'magicbar.desc.logout': 'Sign out',
   'magicbar.desc.contact': 'Send me an email',
+  'magicbar.desc.lies': 'Browse exposed secrets',
 
   // Homepage
   'home.brand': 'Hooper Development',
@@ -93,6 +95,13 @@ const en = {
   'dashboard.sessionCreated': 'Created',
   'dashboard.sessionExpires': 'Expires',
   'dashboard.noSessions': 'No active sessions.',
+
+  // Lies wall
+  'lies.title': 'Lies',
+  'lies.heading': 'The Wall of Lies',
+  'lies.subtitle': 'Every secret that was exposed. Each visit shows a different page.',
+  'lies.empty': 'No lies yet. Submit a secret to begin.',
+  'lies.meta': 'Page {page} of {pages} — {total} lies exposed',
 } as const;
 
 export type TranslationKey = keyof typeof en;

--- a/services/web/src/i18n/es.ts
+++ b/services/web/src/i18n/es.ts
@@ -14,6 +14,7 @@ const es: Record<TranslationKey, string> = {
   'nav.dashboard': 'Panel',
   'nav.logout': 'Cerrar sesión',
   'nav.contact': 'Contacto',
+  'nav.lies': 'Mentiras',
 
   // MagicBar
   'magicbar.placeholder.hero': '¿A dónde quieres ir?',
@@ -32,6 +33,7 @@ const es: Record<TranslationKey, string> = {
   'magicbar.desc.dashboard': 'Ver tu panel',
   'magicbar.desc.logout': 'Cerrar sesión',
   'magicbar.desc.contact': 'Envíame un correo',
+  'magicbar.desc.lies': 'Ver secretos expuestos',
 
   // Homepage
   'home.brand': 'Hooper Development',
@@ -95,6 +97,13 @@ const es: Record<TranslationKey, string> = {
   'dashboard.sessionCreated': 'Creada',
   'dashboard.sessionExpires': 'Expira',
   'dashboard.noSessions': 'No hay sesiones activas.',
+
+  // Lies wall
+  'lies.title': 'Mentiras',
+  'lies.heading': 'El Muro de Mentiras',
+  'lies.subtitle': 'Cada secreto que fue expuesto. Cada visita muestra una página diferente.',
+  'lies.empty': 'Aún no hay mentiras. Envía un secreto para comenzar.',
+  'lies.meta': 'Página {page} de {pages} — {total} mentiras expuestas',
 };
 
 export default es;

--- a/services/web/src/i18n/utils.ts
+++ b/services/web/src/i18n/utils.ts
@@ -60,6 +60,7 @@ export function getMagicBarTranslations(locale: Locale) {
       { titleKey: 'nav.signup' as TranslationKey, descKey: 'magicbar.desc.signup' as TranslationKey, target: localePath(locale, '/signup'), icon: 'fa-user-plus' },
       { titleKey: 'nav.dashboard' as TranslationKey, descKey: 'magicbar.desc.dashboard' as TranslationKey, target: localePath(locale, '/dashboard'), icon: 'fa-gauge' },
       { titleKey: 'nav.logout' as TranslationKey, descKey: 'magicbar.desc.logout' as TranslationKey, target: '/logout', icon: 'fa-right-from-bracket' },
+      { titleKey: 'nav.lies' as TranslationKey, descKey: 'magicbar.desc.lies' as TranslationKey, target: localePath(locale, '/lies'), icon: 'fa-mask' },
       { titleKey: 'nav.contact' as TranslationKey, descKey: 'magicbar.desc.contact' as TranslationKey, target: 'mailto:dev@jredh.com', icon: 'fa-envelope' },
     ].map(item => ({
       title: t(locale, item.titleKey),

--- a/services/web/src/pages/[lang]/lies.astro
+++ b/services/web/src/pages/[lang]/lies.astro
@@ -1,0 +1,70 @@
+---
+import Base from '../../layouts/Base.astro';
+import Topbar from '../../components/Topbar.astro';
+import { isLocale, type Locale } from '../../i18n/config';
+import { t } from '../../i18n/utils';
+
+const { lang } = Astro.params;
+if (!lang || !isLocale(lang)) return Astro.redirect('/en/lies', 302);
+const locale = lang as Locale;
+
+// Fetch a page of lies from the secrets backend.
+const secretsUrl = process.env.SECRETS_URL || 'http://localhost:8082';
+let liesText = '';
+let page = 0;
+let pages = 0;
+let total = 0;
+
+try {
+    const resp = await fetch(`${secretsUrl}/api/lies`);
+    liesText = await resp.text();
+    page = parseInt(resp.headers.get('X-Lies-Page') || '0', 10);
+    pages = parseInt(resp.headers.get('X-Lies-Pages') || '0', 10);
+    total = parseInt(resp.headers.get('X-Lies-Total') || '0', 10);
+} catch (err) {
+    liesText = t(locale, 'lies.empty');
+}
+
+const meta = total > 0
+    ? t(locale, 'lies.meta')
+        .replace('{page}', String(page + 1))
+        .replace('{pages}', String(pages))
+        .replace('{total}', String(total))
+    : '';
+---
+
+<Base title={t(locale, 'lies.title')} lang={locale}>
+    <Topbar slot="topbar" locale={locale} />
+
+    <section class="section">
+        <div class="container">
+            <div class="columns is-centered">
+                <div class="column is-10">
+                    <h1 class="title is-3" style="font-family: 'Montserrat', sans-serif;">
+                        {t(locale, 'lies.heading')}
+                    </h1>
+                    <p class="subtitle is-6 is-muted">{t(locale, 'lies.subtitle')}</p>
+                    {meta && <p class="is-size-7 has-text-grey mb-4">{meta}</p>}
+                    <div class="divider mb-5"></div>
+                    <pre class="lies-wall">{liesText}</pre>
+                </div>
+            </div>
+        </div>
+    </section>
+</Base>
+
+<style>
+.lies-wall {
+    white-space: pre-wrap;
+    word-break: break-word;
+    font-family: monospace;
+    font-size: 0.85rem;
+    line-height: 1.6;
+    background: #fafafa;
+    border: 1px solid #eee;
+    border-radius: 4px;
+    padding: 1.5rem;
+    max-height: 80vh;
+    overflow-y: auto;
+}
+</style>


### PR DESCRIPTION
## Summary

- **Backend**: New `wall` package with background goroutine that pre-builds paginated text blobs of exposed lies (1000/page). Atomic round-robin counter so each `GET /api/lies` returns a different page. Response headers: `X-Lies-Total`, `X-Lies-Page`, `X-Lies-Pages`.
- **Frontend**: New `/[lang]/lies.astro` SSR page that fetches from the secrets backend and renders raw text in a `<pre>` block. Added MagicBar nav entry with `fa-mask` icon.
- **i18n**: English and Spanish translation keys for lies wall page, nav item, and MagicBar description.

## Testing

- 4 wall unit tests passing (empty, single page, round-robin, content verification)
- All existing lens tests passing
- Build succeeds