### PR TITLE
Sync hermit.proto with DB RPCs, add x-hermit-secret interceptor

### DIFF
--- a/services/rust-grpc/proto/hermit.proto
+++ b/services/rust-grpc/proto/hermit.proto
@@ -5,7 +5,7 @@ syntax = "proto3";
 
 package hermit;
 
-option go_package = "github.com/jredh-dev/hermit/cmd/tui/proto";
+option go_package = "github.com/jredh-dev/nexus/cmd/tui/proto";
 
 import "google/protobuf/timestamp.proto";
 
@@ -22,6 +22,18 @@ service Hermit {
 
   // ServerInfo returns server metadata (version, region, uptime).
   rpc ServerInfo(ServerInfoRequest) returns (ServerInfoResponse);
+
+  // Key-value document store
+  rpc KvSet(KvSetRequest) returns (KvSetResponse);
+  rpc KvGet(KvGetRequest) returns (KvGetResponse);
+  rpc KvList(KvListRequest) returns (KvListResponse);
+
+  // Relational SQL-like store
+  rpc SqlInsert(SqlInsertRequest) returns (SqlInsertResponse);
+  rpc SqlQuery(SqlQueryRequest) returns (SqlQueryResponse);
+
+  // Database stats
+  rpc DbStats(DbStatsRequest) returns (DbStatsResponse);
 }
 
 message PingRequest {
@@ -80,4 +92,67 @@ message ServerInfoResponse {
   bool tls_enabled = 6;
   uint32 grpc_port = 7;
   uint32 tcp_port = 8;
+}
+
+message KvSetRequest {
+  string key = 1;
+  bytes value = 2;
+}
+
+message KvSetResponse {
+  bool ok = 1;
+  string error = 2;
+}
+
+message KvGetRequest {
+  string key = 1;
+}
+
+message KvGetResponse {
+  bool found = 1;
+  bytes value = 2;
+  string error = 3;
+}
+
+message KvListRequest {}
+
+message KvListResponse {
+  repeated string keys = 1;
+}
+
+message SqlInsertRequest {
+  string key = 1;
+  string value = 2;
+}
+
+message SqlInsertResponse {
+  bool queued = 1;
+  string error = 2;
+}
+
+message SqlQueryRequest {
+  string key_filter = 1;
+  uint32 limit = 2;
+}
+
+message SqlRow {
+  uint64 id = 1;
+  string key = 2;
+  string value = 3;
+  int64 created_at_unix = 4;
+}
+
+message SqlQueryResponse {
+  repeated SqlRow rows = 1;
+  uint64 total_committed = 2;
+  uint64 pending_writes = 3;
+}
+
+message DbStatsRequest {}
+
+message DbStatsResponse {
+  uint64 doc_key_count = 1;
+  uint64 doc_compressed_bytes = 2;
+  uint64 rel_row_count = 3;
+  uint64 rel_pending_writes = 4;
 }

--- a/services/rust-grpc/src/auth.rs
+++ b/services/rust-grpc/src/auth.rs
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+use tonic::{Request, Status};
+use tracing::warn;
+
+/// Extracts the shared secret from environment and validates it against
+/// the `x-hermit-secret` metadata header on each gRPC request.
+///
+/// If HERMIT_SECRET is not set (dev mode), all requests are allowed.
+pub fn secret_interceptor(req: Request<()>) -> Result<Request<()>, Status> {
+    let expected = match std::env::var("HERMIT_SECRET") {
+        Ok(s) if !s.is_empty() => s,
+        _ => return Ok(req), // dev mode: no secret required
+    };
+
+    match req.metadata().get("x-hermit-secret") {
+        Some(val) => match val.to_str() {
+            Ok(v) if v == expected => Ok(req),
+            _ => {
+                warn!("invalid x-hermit-secret");
+                Err(Status::unauthenticated("invalid secret"))
+            }
+        },
+        None => {
+            warn!("missing x-hermit-secret header");
+            Err(Status::unauthenticated("missing secret"))
+        }
+    }
+}

--- a/services/rust-grpc/src/grpc.rs
+++ b/services/rust-grpc/src/grpc.rs
@@ -2,8 +2,11 @@
 
 use crate::hermit::{
     hermit_server::{Hermit, HermitServer},
-    BenchmarkRequest, BenchmarkResponse, LoginRequest, LoginResponse,
+    BenchmarkRequest, BenchmarkResponse, DbStatsRequest, DbStatsResponse,
+    KvGetRequest, KvGetResponse, KvListRequest, KvListResponse,
+    KvSetRequest, KvSetResponse, LoginRequest, LoginResponse,
     PingRequest, PingResponse, ServerInfoRequest, ServerInfoResponse,
+    SqlInsertRequest, SqlInsertResponse, SqlQueryRequest, SqlQueryResponse,
 };
 use crate::bench;
 use crate::tls::TlsConfig;
@@ -127,6 +130,48 @@ impl Hermit for HermitService {
             tcp_port: self.state.tcp_port as u32,
         }))
     }
+
+    async fn kv_set(
+        &self,
+        _req: Request<KvSetRequest>,
+    ) -> Result<Response<KvSetResponse>, Status> {
+        Err(Status::unimplemented("not yet implemented"))
+    }
+
+    async fn kv_get(
+        &self,
+        _req: Request<KvGetRequest>,
+    ) -> Result<Response<KvGetResponse>, Status> {
+        Err(Status::unimplemented("not yet implemented"))
+    }
+
+    async fn kv_list(
+        &self,
+        _req: Request<KvListRequest>,
+    ) -> Result<Response<KvListResponse>, Status> {
+        Err(Status::unimplemented("not yet implemented"))
+    }
+
+    async fn sql_insert(
+        &self,
+        _req: Request<SqlInsertRequest>,
+    ) -> Result<Response<SqlInsertResponse>, Status> {
+        Err(Status::unimplemented("not yet implemented"))
+    }
+
+    async fn sql_query(
+        &self,
+        _req: Request<SqlQueryRequest>,
+    ) -> Result<Response<SqlQueryResponse>, Status> {
+        Err(Status::unimplemented("not yet implemented"))
+    }
+
+    async fn db_stats(
+        &self,
+        _req: Request<DbStatsRequest>,
+    ) -> Result<Response<DbStatsResponse>, Status> {
+        Err(Status::unimplemented("not yet implemented"))
+    }
 }
 
 pub async fn serve(
@@ -147,7 +192,7 @@ pub async fn serve(
 
     tonic::transport::Server::builder()
         .tls_config(tls)?
-        .add_service(HermitServer::new(svc))
+        .add_service(HermitServer::with_interceptor(svc, crate::auth::secret_interceptor))
         .serve(addr)
         .await?;
 

--- a/services/rust-grpc/src/main.rs
+++ b/services/rust-grpc/src/main.rs
@@ -5,6 +5,7 @@ pub mod hermit {
     tonic::include_proto!("hermit");
 }
 
+mod auth;
 mod grpc;
 mod tcp;
 mod tls;


### PR DESCRIPTION
## Summary
- Update `hermit.proto` with 6 DB RPCs the TUI already expects: KvSet/Get/List, SqlInsert/Query, DbStats
- Add `auth.rs` tonic interceptor that validates `x-hermit-secret` metadata against `HERMIT_SECRET` env var (passthrough when unset for dev mode)
- Wire interceptor via `HermitServer::with_interceptor`
- Add stub implementations returning `Status::unimplemented` (real impls in next PR)
- Fix `go_package` option to match current TUI path

`cargo check` and `go vet` pass.