### PR TITLE
Add Dockerfile and Cloud Run deploy workflow for hermit

### DIFF
--- a/.github/workflows/deploy-hermit-dev.yml
+++ b/.github/workflows/deploy-hermit-dev.yml
@@ -1,0 +1,103 @@
+name: Deploy Hermit to Cloud Run (DEV)
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'services/rust-grpc/**'
+  workflow_dispatch:
+
+env:
+  GCP_PROJECT_ID: dea-noctua
+  GCP_REGION: us-central1
+  SERVICE_NAME: nexus-hermit-dev
+  IMAGE_NAME: gcr.io/dea-noctua/nexus-hermit-dev
+
+jobs:
+  deploy:
+    name: Build and Deploy Hermit to Cloud Run DEV
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set version variables
+        id: version
+        run: |
+          VERSION="v0.0.1.$(git rev-list --count HEAD)"
+          COMMIT=$(git rev-parse --short HEAD)
+          BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+          echo "COMMIT=$COMMIT" >> $GITHUB_OUTPUT
+          echo "BUILD_DATE=$BUILD_DATE" >> $GITHUB_OUTPUT
+          echo "Building version: $VERSION (commit: $COMMIT)"
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.WIF_PROVIDER }}
+          service_account: ${{ secrets.WIF_SERVICE_ACCOUNT }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Configure Docker for GCR
+        run: gcloud auth configure-docker
+
+      - name: Build Docker image
+        run: |
+          docker build \
+            -f services/rust-grpc/Dockerfile \
+            -t ${{ env.IMAGE_NAME }}:${{ steps.version.outputs.VERSION }} \
+            -t ${{ env.IMAGE_NAME }}:latest \
+            services/rust-grpc/
+
+      - name: Push Docker image to GCR
+        run: |
+          docker push ${{ env.IMAGE_NAME }}:${{ steps.version.outputs.VERSION }}
+          docker push ${{ env.IMAGE_NAME }}:latest
+
+      - name: Deploy to Cloud Run
+        run: |
+          VERSION_LABEL=$(echo "${{ steps.version.outputs.VERSION }}" | tr '.' '-')
+          gcloud run deploy ${{ env.SERVICE_NAME }} \
+            --image ${{ env.IMAGE_NAME }}:${{ steps.version.outputs.VERSION }} \
+            --region ${{ env.GCP_REGION }} \
+            --platform managed \
+            --no-allow-unauthenticated \
+            --port 8080 \
+            --memory 256Mi \
+            --cpu 1 \
+            --min-instances 0 \
+            --max-instances 3 \
+            --set-env-vars "ENVIRONMENT=dev,RUST_LOG=hermit_server=info" \
+            --set-secrets "HERMIT_SECRET=hermit-secret-dev:latest" \
+            --service-account ${{ secrets.WIF_SERVICE_ACCOUNT }} \
+            --labels "environment=dev,app=nexus-hermit,version=$VERSION_LABEL"
+
+      - name: Get service URL
+        id: service-url
+        run: |
+          SERVICE_URL=$(gcloud run services describe ${{ env.SERVICE_NAME }} \
+            --region ${{ env.GCP_REGION }} \
+            --format 'value(status.url)')
+          echo "url=$SERVICE_URL" >> $GITHUB_OUTPUT
+          echo "Service deployed to: $SERVICE_URL"
+
+      - name: Summary
+        run: |
+          echo "## Deployment Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- **Environment**: DEV" >> $GITHUB_STEP_SUMMARY
+          echo "- **Version**: ${{ steps.version.outputs.VERSION }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Commit**: ${{ steps.version.outputs.COMMIT }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Service URL**: ${{ steps.service-url.outputs.url }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Image**: ${{ env.IMAGE_NAME }}:${{ steps.version.outputs.VERSION }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Auth**: IAM-gated (--no-allow-unauthenticated)" >> $GITHUB_STEP_SUMMARY

--- a/services/rust-grpc/Dockerfile
+++ b/services/rust-grpc/Dockerfile
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+# Build stage
+FROM rust:1.85-slim-bookworm AS builder
+
+RUN apt-get update && apt-get install -y protobuf-compiler && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Cache dependencies by building with empty src first
+COPY Cargo.toml Cargo.lock ./
+COPY proto/ proto/
+COPY build.rs ./
+RUN mkdir src && echo 'fn main() {}' > src/main.rs
+RUN cargo build --release 2>/dev/null || true
+RUN rm -rf src
+
+# Build real binary
+COPY src/ src/
+RUN cargo build --release
+
+# Runtime stage
+FROM debian:bookworm-slim
+
+RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
+
+RUN groupadd -g 1000 appuser && useradd -u 1000 -g appuser -m appuser
+
+COPY --from=builder /app/target/release/hermit-server /usr/local/bin/hermit-server
+
+USER appuser
+
+# Cloud Run sends traffic to PORT env var (default 8080)
+# hermit uses --grpc-port flag
+ENV PORT=8080
+EXPOSE 8080
+
+# Cloud Run terminates TLS -- hermit should NOT use self-signed TLS inside container.
+# We need a flag for this. For now, the server always does TLS.
+# TODO: Add --no-tls flag to hermit-server for Cloud Run mode.
+# For now, self-signed TLS inside the container is fine -- Cloud Run connects to it.
+
+ENTRYPOINT ["hermit-server"]
+CMD ["--grpc-port", "8080"]


### PR DESCRIPTION
## Summary
- Multi-stage Rust Dockerfile for hermit (builder + minimal runtime)
- GitHub Actions workflow `deploy-hermit-dev.yml` for Cloud Run deployment
- Uses Workload Identity Federation (WIF) — no service account keys
- Reads `HERMIT_SECRET` from GCP Secret Manager at runtime
- Cherry-picks WS3 TCP removal commit as base

## Depends on
- PR #55 (TCP removal) — must merge first

## Pre-deploy requirements
- Create `hermit-secret-dev` in GCP Secret Manager
- Grant Cloud Run service account access to the secret