### PR TITLE
Add quantization port (microquant.go)

### DIFF
--- a/research/ml/README.md
+++ b/research/ml/README.md
@@ -16,6 +16,7 @@ All files use the `research` build tag and are excluded from default compilation
 | Flash Attention | `microflash.go` | Done |
 | Scalar Autograd | `value.go` | Done |
 | GPT (char-level) | `microgpt.go` | Done |
+| Quantization | `microquant.go` | Done |
 
 ## Run
 
@@ -24,7 +25,7 @@ go test -tags research -v ./research/ml/
 go test -tags research -bench=. -benchmem ./research/ml/
 ```
 
-To run demos interactively, call `ml.RunMicrotokenizer()`, `ml.RunMicroflash()`, or `ml.RunMicrogpt()` from a tagged main or test.
+To run demos interactively, call `ml.RunMicrotokenizer()`, `ml.RunMicroflash()`, `ml.RunMicrogpt()`, or `ml.RunMicroquant()` from a tagged main or test.
 
 ## Design
 

--- a/research/ml/microquant.go
+++ b/research/ml/microquant.go
@@ -1,0 +1,654 @@
+//go:build research
+
+// How to shrink a model by 4x with minimal quality loss -- the math behind INT8 and INT4
+// weight quantization, demonstrated end-to-end: train, quantize, dequantize, compare.
+//
+// Reference: Dettmers et al., "LLM.int8(): 8-bit Matrix Multiplication for Transformers
+// at Scale" (2022). https://arxiv.org/abs/2208.07339
+// Also: Frantar et al., "GPTQ: Accurate Post-Training Quantization for Generative
+// Pre-trained Transformers" (2022). https://arxiv.org/abs/2210.17323
+//
+// Port of microquant.py from mathews-tom/no-magic to Go.
+// AGPL-3.0 -- see LICENSE in repo root.
+package ml
+
+import (
+	"fmt"
+	"math"
+	"math/rand/v2"
+)
+
+// === QUANTIZATION FUNCTIONS ===
+//
+// Quantization maps continuous float weights to a discrete integer grid.
+// The core insight: neural network weights are approximately normally distributed
+// with small magnitude. Most values cluster near zero, so mapping to [-127, +127]
+// (INT8) or [-8, +7] (INT4) loses surprisingly little information. The network's
+// nonlinearities and redundancy absorb the rounding error.
+
+// QuantizedMatrix holds integer weights and their quantization parameters.
+type QuantizedMatrix struct {
+	Data      [][]int
+	Scale     float64
+	ZeroPoint int       // only used by zero-point quantization
+	Scales    []float64 // only used by per-channel quantization (one scale per row)
+}
+
+// QuantizeAbsmaxInt8 scales the float range [-max|W|, +max|W|] to [-127, +127].
+// Symmetric around zero -- assumes weight distribution is roughly centered.
+// This is the simplest quantization scheme and the baseline for everything else.
+//
+// Math: q_i = clamp(round(w_i / s), -127, 127)  where s = max(|W|) / 127
+func QuantizeAbsmaxInt8(weights [][]float64) QuantizedMatrix {
+	maxAbs := matMaxAbs(weights)
+	if maxAbs == 0 {
+		return QuantizedMatrix{Data: zeroIntMatrix(weights), Scale: 1.0}
+	}
+	scale := maxAbs / 127.0
+	data := make([][]int, len(weights))
+	for i, row := range weights {
+		data[i] = make([]int, len(row))
+		for j, w := range row {
+			data[i][j] = clampInt(int(math.Round(w/scale)), -127, 127)
+		}
+	}
+	return QuantizedMatrix{Data: data, Scale: scale}
+}
+
+// QuantizeAbsmaxInt4 maps to [-8, +7] (4-bit signed integer range).
+// 8x compression vs float32. The quantization grid is 16x coarser than INT8,
+// so rounding errors are substantially larger. Neural nets tolerate this because
+// individual weight precision matters less than the collective statistical
+// properties of weight matrices.
+//
+// Signpost: production INT4 (GPTQ, AWQ) uses calibration data to minimize
+// output error rather than naive round-to-nearest.
+func QuantizeAbsmaxInt4(weights [][]float64) QuantizedMatrix {
+	maxAbs := matMaxAbs(weights)
+	if maxAbs == 0 {
+		return QuantizedMatrix{Data: zeroIntMatrix(weights), Scale: 1.0}
+	}
+	scale := maxAbs / 7.0
+	data := make([][]int, len(weights))
+	for i, row := range weights {
+		data[i] = make([]int, len(row))
+		for j, w := range row {
+			data[i][j] = clampInt(int(math.Round(w/scale)), -8, 7)
+		}
+	}
+	return QuantizedMatrix{Data: data, Scale: scale}
+}
+
+// QuantizeZeropointInt8 maps [min_W, max_W] to [0, 255] (asymmetric).
+// Unlike absmax which centers on zero, zero-point shifts the mapping so the
+// full 8-bit range covers the actual weight range. More accurate when weights
+// are not symmetric around zero.
+//
+// Math: scale = (w_max - w_min) / 255
+//
+//	zero_point = round(-w_min / scale)
+//	q_i = clamp(round(w_i / scale) + zero_point, 0, 255)
+func QuantizeZeropointInt8(weights [][]float64) QuantizedMatrix {
+	wMin, wMax := matMinMax(weights)
+	if wMax == wMin {
+		return QuantizedMatrix{Data: zeroIntMatrix(weights), Scale: 1.0}
+	}
+	scale := (wMax - wMin) / 255.0
+	zeroPoint := int(math.Round(-wMin / scale))
+	data := make([][]int, len(weights))
+	for i, row := range weights {
+		data[i] = make([]int, len(row))
+		for j, w := range row {
+			data[i][j] = clampInt(int(math.Round(w/scale))+zeroPoint, 0, 255)
+		}
+	}
+	return QuantizedMatrix{Data: data, Scale: scale, ZeroPoint: zeroPoint}
+}
+
+// QuantizePerChannelInt8 gives each output row its own scale factor.
+// Per-tensor quantization uses one scale for the entire matrix, so a single
+// outlier weight forces the entire grid to be coarse. Per-channel (per-row)
+// quantization lets each output neuron use its own range, dramatically reducing
+// error for matrices with non-uniform row magnitudes.
+//
+// Signpost: LLM.int8() (Dettmers 2022) goes further with mixed-precision
+// decomposition -- outlier channels stay in fp16 while the rest quantize to INT8.
+func QuantizePerChannelInt8(weights [][]float64) QuantizedMatrix {
+	data := make([][]int, len(weights))
+	scales := make([]float64, len(weights))
+	for i, row := range weights {
+		maxAbs := 0.0
+		for _, w := range row {
+			if a := math.Abs(w); a > maxAbs {
+				maxAbs = a
+			}
+		}
+		if maxAbs == 0 {
+			scales[i] = 1.0
+		} else {
+			scales[i] = maxAbs / 127.0
+		}
+		data[i] = make([]int, len(row))
+		for j, w := range row {
+			data[i][j] = clampInt(int(math.Round(w/scales[i])), -127, 127)
+		}
+	}
+	return QuantizedMatrix{Data: data, Scales: scales}
+}
+
+// === DEQUANTIZATION FUNCTIONS ===
+// Reverse the quantization mapping to recover approximate float weights.
+
+// DequantizeAbsmax returns w_hat = q * scale.
+func DequantizeAbsmax(qm QuantizedMatrix) [][]float64 {
+	out := make([][]float64, len(qm.Data))
+	for i, row := range qm.Data {
+		out[i] = make([]float64, len(row))
+		for j, q := range row {
+			out[i][j] = float64(q) * qm.Scale
+		}
+	}
+	return out
+}
+
+// DequantizeZeropoint returns w_hat = (q - zeroPoint) * scale.
+func DequantizeZeropoint(qm QuantizedMatrix) [][]float64 {
+	out := make([][]float64, len(qm.Data))
+	for i, row := range qm.Data {
+		out[i] = make([]float64, len(row))
+		for j, q := range row {
+			out[i][j] = float64(q-qm.ZeroPoint) * qm.Scale
+		}
+	}
+	return out
+}
+
+// DequantizePerChannel returns w_hat[i] = q[i] * scales[row].
+func DequantizePerChannel(qm QuantizedMatrix) [][]float64 {
+	out := make([][]float64, len(qm.Data))
+	for i, row := range qm.Data {
+		out[i] = make([]float64, len(row))
+		for j, q := range row {
+			out[i][j] = float64(q) * qm.Scales[i]
+		}
+	}
+	return out
+}
+
+// === FLOAT-BASED OPERATIONS (no autograd, for quantized inference) ===
+// After quantization, weights are dequantized back to floats. These functions
+// mirror the Value-based versions but operate on raw floats -- no gradient tracking
+// because quantized models are inference-only.
+
+// LinearFloat computes y = W @ x with plain floats.
+func LinearFloat(x []float64, w [][]float64) []float64 {
+	out := make([]float64, len(w))
+	for i, wRow := range w {
+		s := 0.0
+		for j, xj := range x {
+			s += wRow[j] * xj
+		}
+		out[i] = s
+	}
+	return out
+}
+
+// SoftmaxFloat computes stable softmax on plain floats.
+func SoftmaxFloat(logits []float64) []float64 {
+	maxVal := logits[0]
+	for _, v := range logits[1:] {
+		if v > maxVal {
+			maxVal = v
+		}
+	}
+	expVals := make([]float64, len(logits))
+	total := 0.0
+	for i, v := range logits {
+		expVals[i] = math.Exp(v - maxVal)
+		total += expVals[i]
+	}
+	out := make([]float64, len(logits))
+	for i, e := range expVals {
+		out[i] = e / total
+	}
+	return out
+}
+
+// RMSNormFloat applies RMSNorm on plain floats.
+func RMSNormFloat(x []float64) []float64 {
+	meanSq := 0.0
+	for _, xi := range x {
+		meanSq += xi * xi
+	}
+	meanSq /= float64(len(x))
+	scale := 1.0 / math.Sqrt(meanSq+1e-5)
+	out := make([]float64, len(x))
+	for i, xi := range x {
+		out[i] = xi * scale
+	}
+	return out
+}
+
+// === FLOAT GPT FORWARD PASS (for quantized inference) ===
+// Structurally identical to GPTForward but operates on dequantized float weights.
+// This separation keeps autograd overhead out of the quantization evaluation path.
+
+// FloatGPTParams holds float64 weight matrices keyed by name (matching GPTParams layout).
+type FloatGPTParams struct {
+	Config GPTConfig
+	Wte    [][]float64
+	Wpe    [][]float64
+	Layers []FloatGPTLayerParams
+	LMHead [][]float64
+}
+
+// FloatGPTLayerParams holds float weights for one transformer layer.
+type FloatGPTLayerParams struct {
+	AttnWQ, AttnWK, AttnWV, AttnWO [][]float64
+	MLPFC1, MLPFC2                 [][]float64
+}
+
+// ExtractFloatParams converts Value-based GPTParams to plain float64 matrices.
+func ExtractFloatParams(p *GPTParams) *FloatGPTParams {
+	fp := &FloatGPTParams{Config: p.Config}
+	fp.Wte = extractMatrix(p.Wte)
+	fp.Wpe = extractMatrix(p.Wpe)
+	fp.Layers = make([]FloatGPTLayerParams, len(p.Layers))
+	for i := range p.Layers {
+		fp.Layers[i] = FloatGPTLayerParams{
+			AttnWQ: extractMatrix(p.Layers[i].AttnWQ),
+			AttnWK: extractMatrix(p.Layers[i].AttnWK),
+			AttnWV: extractMatrix(p.Layers[i].AttnWV),
+			AttnWO: extractMatrix(p.Layers[i].AttnWO),
+			MLPFC1: extractMatrix(p.Layers[i].MLPFC1),
+			MLPFC2: extractMatrix(p.Layers[i].MLPFC2),
+		}
+	}
+	fp.LMHead = extractMatrix(p.LMHead)
+	return fp
+}
+
+// GPTForwardFloat runs a single-token forward pass with plain float weights. No gradient tracking.
+func GPTForwardFloat(tokenID, posID int, keys, values *[][]float64Slice, fp *FloatGPTParams) []float64 {
+	cfg := fp.Config
+	headDim := cfg.HeadDim()
+
+	tokEmb := fp.Wte[tokenID]
+	posEmb := fp.Wpe[posID]
+	x := make([]float64, cfg.NEmbd)
+	for i := range x {
+		x[i] = tokEmb[i] + posEmb[i]
+	}
+	x = RMSNormFloat(x)
+
+	for li := range fp.Layers {
+		layer := &fp.Layers[li]
+		xResidual := make([]float64, len(x))
+		copy(xResidual, x)
+
+		x = RMSNormFloat(x)
+		q := LinearFloat(x, layer.AttnWQ)
+		k := LinearFloat(x, layer.AttnWK)
+		v := LinearFloat(x, layer.AttnWV)
+
+		(*keys)[li] = append((*keys)[li], k)
+		(*values)[li] = append((*values)[li], v)
+
+		xAttn := make([]float64, 0, cfg.NEmbd)
+		for head := 0; head < cfg.NHead; head++ {
+			hs := head * headDim
+
+			qHead := q[hs : hs+headDim]
+			cachedK := (*keys)[li]
+			cachedV := (*values)[li]
+			seqLen := len(cachedK)
+
+			scale := 1.0 / math.Sqrt(float64(headDim))
+			attnLogits := make([]float64, seqLen)
+			for t := 0; t < seqLen; t++ {
+				kT := cachedK[t]
+				dot := 0.0
+				for j := 0; j < headDim; j++ {
+					dot += qHead[j] * kT[hs+j]
+				}
+				attnLogits[t] = dot * scale
+			}
+
+			attnWeights := SoftmaxFloat(attnLogits)
+
+			headOutput := make([]float64, headDim)
+			for j := 0; j < headDim; j++ {
+				s := 0.0
+				for t := 0; t < seqLen; t++ {
+					s += attnWeights[t] * cachedV[t][hs+j]
+				}
+				headOutput[j] = s
+			}
+			xAttn = append(xAttn, headOutput...)
+		}
+
+		x = LinearFloat(xAttn, layer.AttnWO)
+		for i := range x {
+			x[i] += xResidual[i]
+		}
+		xResidual = make([]float64, len(x))
+		copy(xResidual, x)
+
+		x = RMSNormFloat(x)
+		x = LinearFloat(x, layer.MLPFC1)
+		for i := range x {
+			if x[i] < 0 {
+				x[i] = 0 // ReLU
+			}
+		}
+		x = LinearFloat(x, layer.MLPFC2)
+		for i := range x {
+			x[i] += xResidual[i]
+		}
+	}
+
+	return LinearFloat(x, fp.LMHead)
+}
+
+// float64Slice is an alias to enable KV cache as [][]float64Slice (per-layer list of vectors).
+type float64Slice = []float64
+
+// === EVALUATION HELPERS ===
+
+// EvalQuantLoss computes average cross-entropy loss on evaluation documents using float forward pass.
+func EvalQuantLoss(fp *FloatGPTParams, docs []string, chars []rune, charToIdx map[rune]int, bos int) float64 {
+	cfg := fp.Config
+	totalLoss := 0.0
+	totalTokens := 0
+
+	for _, doc := range docs {
+		tokens := Tokenize(doc, charToIdx, bos)
+		seqLen := cfg.BlockSize
+		if len(tokens)-1 < seqLen {
+			seqLen = len(tokens) - 1
+		}
+
+		keys := make([][]float64Slice, cfg.NLayer)
+		values := make([][]float64Slice, cfg.NLayer)
+
+		for pos := 0; pos < seqLen; pos++ {
+			logits := GPTForwardFloat(tokens[pos], pos, &keys, &values, fp)
+			probs := SoftmaxFloat(logits)
+			pTarget := math.Max(probs[tokens[pos+1]], 1e-10)
+			totalLoss += -math.Log(pTarget)
+			totalTokens++
+		}
+	}
+	if totalTokens == 0 {
+		return math.Inf(1)
+	}
+	return totalLoss / float64(totalTokens)
+}
+
+// GenerateQuantSample generates a single sample from float GPT params.
+func GenerateQuantSample(fp *FloatGPTParams, chars []rune, bos int, temperature float64, rng *rand.Rand) string {
+	cfg := fp.Config
+	keys := make([][]float64Slice, cfg.NLayer)
+	values := make([][]float64Slice, cfg.NLayer)
+
+	tokenID := bos
+	var generated []rune
+
+	for pos := 0; pos < cfg.BlockSize; pos++ {
+		logits := GPTForwardFloat(tokenID, pos, &keys, &values, fp)
+		scaled := make([]float64, len(logits))
+		for i, l := range logits {
+			scaled[i] = l / temperature
+		}
+		probs := SoftmaxFloat(scaled)
+		tokenID = weightedSampleFloat(probs, rng)
+		if tokenID == bos {
+			break
+		}
+		generated = append(generated, chars[tokenID])
+	}
+	return string(generated)
+}
+
+// QuantizeAllParams applies a quantization scheme to all float weight matrices and returns
+// dequantized float params. The method string selects the scheme.
+func QuantizeAllParams(fp *FloatGPTParams, method string) *FloatGPTParams {
+	qfp := &FloatGPTParams{Config: fp.Config}
+	q := func(m [][]float64) [][]float64 {
+		switch method {
+		case "int8-absmax":
+			return DequantizeAbsmax(QuantizeAbsmaxInt8(m))
+		case "int4-absmax":
+			return DequantizeAbsmax(QuantizeAbsmaxInt4(m))
+		case "int8-zeropoint":
+			return DequantizeZeropoint(QuantizeZeropointInt8(m))
+		case "int8-perchannel":
+			return DequantizePerChannel(QuantizePerChannelInt8(m))
+		default:
+			panic("unknown quantization method: " + method)
+		}
+	}
+	qfp.Wte = q(fp.Wte)
+	qfp.Wpe = q(fp.Wpe)
+	qfp.Layers = make([]FloatGPTLayerParams, len(fp.Layers))
+	for i := range fp.Layers {
+		qfp.Layers[i] = FloatGPTLayerParams{
+			AttnWQ: q(fp.Layers[i].AttnWQ),
+			AttnWK: q(fp.Layers[i].AttnWK),
+			AttnWV: q(fp.Layers[i].AttnWV),
+			AttnWO: q(fp.Layers[i].AttnWO),
+			MLPFC1: q(fp.Layers[i].MLPFC1),
+			MLPFC2: q(fp.Layers[i].MLPFC2),
+		}
+	}
+	qfp.LMHead = q(fp.LMHead)
+	return qfp
+}
+
+// ComputeRoundtripError returns max |w - dequant(quant(w))| across all weights.
+func ComputeRoundtripError(original, dequantized *FloatGPTParams) float64 {
+	maxErr := 0.0
+	check := func(a, b [][]float64) {
+		for i := range a {
+			for j := range a[i] {
+				if e := math.Abs(a[i][j] - b[i][j]); e > maxErr {
+					maxErr = e
+				}
+			}
+		}
+	}
+	check(original.Wte, dequantized.Wte)
+	check(original.Wpe, dequantized.Wpe)
+	for i := range original.Layers {
+		check(original.Layers[i].AttnWQ, dequantized.Layers[i].AttnWQ)
+		check(original.Layers[i].AttnWK, dequantized.Layers[i].AttnWK)
+		check(original.Layers[i].AttnWV, dequantized.Layers[i].AttnWV)
+		check(original.Layers[i].AttnWO, dequantized.Layers[i].AttnWO)
+		check(original.Layers[i].MLPFC1, dequantized.Layers[i].MLPFC1)
+		check(original.Layers[i].MLPFC2, dequantized.Layers[i].MLPFC2)
+	}
+	check(original.LMHead, dequantized.LMHead)
+	return maxErr
+}
+
+// ComputeModelSize returns model size in bytes at the given bit width.
+func ComputeModelSize(fp *FloatGPTParams, bits int) int {
+	n := 0
+	count := func(m [][]float64) {
+		for _, row := range m {
+			n += len(row)
+		}
+	}
+	count(fp.Wte)
+	count(fp.Wpe)
+	for i := range fp.Layers {
+		count(fp.Layers[i].AttnWQ)
+		count(fp.Layers[i].AttnWK)
+		count(fp.Layers[i].AttnWV)
+		count(fp.Layers[i].AttnWO)
+		count(fp.Layers[i].MLPFC1)
+		count(fp.Layers[i].MLPFC2)
+	}
+	count(fp.LMHead)
+	return n * bits / 8
+}
+
+// === DEMO ===
+
+// RunMicroquant trains a tiny GPT, applies 4 quantization methods, and compares results.
+func RunMicroquant() {
+	fmt.Println("=== MicroQuant: Weight Quantization Demo ===")
+	fmt.Println()
+
+	// Small built-in corpus
+	docs := []string{
+		"emma", "olivia", "ava", "sophia", "isabella",
+		"mia", "charlotte", "amelia", "harper", "evelyn",
+		"abigail", "emily", "elizabeth", "mila", "ella",
+		"avery", "sofia", "camila", "aria", "scarlett",
+		"victoria", "madison", "luna", "grace", "chloe",
+		"penelope", "layla", "riley", "zoey", "nora",
+		"lily", "eleanor", "hannah", "lillian", "addison",
+		"aubrey", "ellie", "stella", "natalie", "zoe",
+		"leah", "hazel", "violet", "aurora", "savannah",
+		"audrey", "brooklyn", "bella", "claire", "skylar",
+	}
+
+	rng := rand.New(rand.NewPCG(42, 0))
+
+	// Phase 1: Train base model (800 steps, matching Python)
+	fmt.Println("Phase 1: Training base model...")
+	result := TrainGPT(docs, 800, rng, true)
+
+	// Phase 2: Extract float weights
+	fmt.Println("\n=== Extracting Float32 Weights ===")
+	fp := ExtractFloatParams(result.Params)
+
+	chars, charToIdx, bos := BuildVocab(docs)
+	evalDocs := docs[:20] // smaller eval set for demo speed
+
+	baselineLoss := EvalQuantLoss(fp, evalDocs, chars, charToIdx, bos)
+	fmt.Printf("Float32 baseline loss: %.4f\n", baselineLoss)
+
+	// Phase 3-6: Apply quantization methods
+	methods := []struct {
+		name   string
+		method string
+		bits   int
+	}{
+		{"INT8 absmax", "int8-absmax", 8},
+		{"INT4 absmax", "int4-absmax", 4},
+		{"INT8 zero-point", "int8-zeropoint", 8},
+		{"INT8 per-channel", "int8-perchannel", 8},
+	}
+
+	type quantResult struct {
+		name string
+		bits int
+		loss float64
+		err  float64
+	}
+	var results []quantResult
+
+	for _, m := range methods {
+		fmt.Printf("\n=== %s Quantization ===\n", m.name)
+		qfp := QuantizeAllParams(fp, m.method)
+		loss := EvalQuantLoss(qfp, evalDocs, chars, charToIdx, bos)
+		err := ComputeRoundtripError(fp, qfp)
+		delta := (loss - baselineLoss) / baselineLoss * 100
+		fmt.Printf("%s loss: %.4f (delta: %+.1f%%)\n", m.name, loss, delta)
+		results = append(results, quantResult{m.name, m.bits, loss, err})
+	}
+
+	// Phase 7: Comparison table
+	size32 := ComputeModelSize(fp, 32)
+	fmt.Println()
+	fmt.Println("========================================")
+	fmt.Println("=== Quantization Results ===")
+	fmt.Println("========================================")
+	fmt.Printf("%-24s %4s %9s %8s %8s %10s\n", "Method", "Bits", "Size", "Loss", "Delta", "Max Err")
+	fmt.Printf("%-24s %4s %9s %8s %8s %10s\n", "------", "----", "----", "----", "-----", "-------")
+	fmt.Printf("%-24s %4d %7d B %8.4f %8s %10s\n", "Float32 (baseline)", 32, size32, baselineLoss, "---", "---")
+	for _, r := range results {
+		size := ComputeModelSize(fp, r.bits)
+		delta := (r.loss - baselineLoss) / baselineLoss * 100
+		fmt.Printf("%-24s %4d %7d B %8.4f %+7.1f%% %10.6f\n", r.name, r.bits, size, r.loss, delta, r.err)
+	}
+	fmt.Printf("\nCompression: float32->INT8 = %.1fx, float32->INT4 = %.1fx\n",
+		float64(size32)/float64(ComputeModelSize(fp, 8)),
+		float64(size32)/float64(ComputeModelSize(fp, 4)))
+}
+
+// === INTERNAL HELPERS ===
+
+func extractMatrix(m [][]*Value) [][]float64 {
+	out := make([][]float64, len(m))
+	for i, row := range m {
+		out[i] = make([]float64, len(row))
+		for j, v := range row {
+			out[i][j] = v.Data
+		}
+	}
+	return out
+}
+
+func matMaxAbs(m [][]float64) float64 {
+	maxAbs := 0.0
+	for _, row := range m {
+		for _, w := range row {
+			if a := math.Abs(w); a > maxAbs {
+				maxAbs = a
+			}
+		}
+	}
+	return maxAbs
+}
+
+func matMinMax(m [][]float64) (float64, float64) {
+	wMin, wMax := m[0][0], m[0][0]
+	for _, row := range m {
+		for _, w := range row {
+			if w < wMin {
+				wMin = w
+			}
+			if w > wMax {
+				wMax = w
+			}
+		}
+	}
+	return wMin, wMax
+}
+
+func clampInt(v, lo, hi int) int {
+	if v < lo {
+		return lo
+	}
+	if v > hi {
+		return hi
+	}
+	return v
+}
+
+func zeroIntMatrix(ref [][]float64) [][]int {
+	out := make([][]int, len(ref))
+	for i, row := range ref {
+		out[i] = make([]int, len(row))
+	}
+	return out
+}
+
+func weightedSampleFloat(weights []float64, rng *rand.Rand) int {
+	total := 0.0
+	for _, w := range weights {
+		total += w
+	}
+	r := rng.Float64() * total
+	cum := 0.0
+	for i, w := range weights {
+		cum += w
+		if r <= cum {
+			return i
+		}
+	}
+	return len(weights) - 1
+}

--- a/research/ml/microquant_test.go
+++ b/research/ml/microquant_test.go
@@ -1,0 +1,362 @@
+//go:build research
+
+package ml
+
+import (
+	"math"
+	"math/rand/v2"
+	"testing"
+)
+
+// === QUANTIZATION / DEQUANTIZATION ROUNDTRIP ===
+
+func TestQuantizeAbsmaxInt8Roundtrip(t *testing.T) {
+	weights := [][]float64{
+		{0.1, -0.2, 0.3},
+		{-0.05, 0.15, -0.25},
+	}
+	qm := QuantizeAbsmaxInt8(weights)
+	deq := DequantizeAbsmax(qm)
+
+	// Max error should be small (scale = 0.3/127 ≈ 0.00236)
+	for i := range weights {
+		for j := range weights[i] {
+			err := math.Abs(weights[i][j] - deq[i][j])
+			if err > 0.003 {
+				t.Errorf("[%d][%d]: error %.6f > 0.003 (orig=%.4f, deq=%.4f)",
+					i, j, err, weights[i][j], deq[i][j])
+			}
+		}
+	}
+}
+
+func TestQuantizeAbsmaxInt4Roundtrip(t *testing.T) {
+	weights := [][]float64{
+		{0.1, -0.2, 0.3},
+		{-0.05, 0.15, -0.25},
+	}
+	qm := QuantizeAbsmaxInt4(weights)
+	deq := DequantizeAbsmax(qm)
+
+	// INT4 has coarser grid (scale = 0.3/7 ≈ 0.0429), max error can be larger
+	for i := range weights {
+		for j := range weights[i] {
+			err := math.Abs(weights[i][j] - deq[i][j])
+			if err > 0.05 {
+				t.Errorf("[%d][%d]: error %.6f > 0.05 (orig=%.4f, deq=%.4f)",
+					i, j, err, weights[i][j], deq[i][j])
+			}
+		}
+	}
+}
+
+func TestQuantizeZeropointInt8Roundtrip(t *testing.T) {
+	weights := [][]float64{
+		{0.1, 0.5, 0.9},
+		{0.2, 0.6, 0.8},
+	}
+	qm := QuantizeZeropointInt8(weights)
+	deq := DequantizeZeropoint(qm)
+
+	for i := range weights {
+		for j := range weights[i] {
+			err := math.Abs(weights[i][j] - deq[i][j])
+			if err > 0.005 {
+				t.Errorf("[%d][%d]: error %.6f > 0.005", i, j, err)
+			}
+		}
+	}
+}
+
+func TestQuantizePerChannelInt8Roundtrip(t *testing.T) {
+	// Two rows with very different scales -- per-channel should handle this well
+	weights := [][]float64{
+		{0.001, -0.002, 0.003}, // tiny values
+		{1.0, -2.0, 3.0},       // large values
+	}
+	qm := QuantizePerChannelInt8(weights)
+	deq := DequantizePerChannel(qm)
+
+	// Per-channel should have much lower error on the small row than per-tensor
+	for j := range weights[0] {
+		err := math.Abs(weights[0][j] - deq[0][j])
+		if err > 0.00005 {
+			t.Errorf("small row [0][%d]: error %.8f > 0.00005", j, err)
+		}
+	}
+}
+
+func TestQuantizeAbsmaxInt8ClampsSaturated(t *testing.T) {
+	// All values are the same magnitude -- should map to exactly ±127
+	weights := [][]float64{{1.0, -1.0}}
+	qm := QuantizeAbsmaxInt8(weights)
+	if qm.Data[0][0] != 127 || qm.Data[0][1] != -127 {
+		t.Errorf("Expected [127, -127], got %v", qm.Data[0])
+	}
+}
+
+func TestQuantizeZeroMatrix(t *testing.T) {
+	weights := [][]float64{{0, 0}, {0, 0}}
+
+	qm8 := QuantizeAbsmaxInt8(weights)
+	if qm8.Scale != 1.0 {
+		t.Errorf("INT8 zero matrix: scale = %f, want 1.0", qm8.Scale)
+	}
+
+	qm4 := QuantizeAbsmaxInt4(weights)
+	if qm4.Scale != 1.0 {
+		t.Errorf("INT4 zero matrix: scale = %f, want 1.0", qm4.Scale)
+	}
+}
+
+// === INT8 VS INT4 ERROR COMPARISON ===
+
+func TestInt8LowerErrorThanInt4(t *testing.T) {
+	rng := rand.New(rand.NewPCG(42, 0))
+	weights := make([][]float64, 10)
+	for i := range weights {
+		weights[i] = make([]float64, 10)
+		for j := range weights[i] {
+			weights[i][j] = rng.NormFloat64() * 0.1
+		}
+	}
+
+	deq8 := DequantizeAbsmax(QuantizeAbsmaxInt8(weights))
+	deq4 := DequantizeAbsmax(QuantizeAbsmaxInt4(weights))
+
+	err8, err4 := 0.0, 0.0
+	for i := range weights {
+		for j := range weights[i] {
+			err8 += math.Abs(weights[i][j] - deq8[i][j])
+			err4 += math.Abs(weights[i][j] - deq4[i][j])
+		}
+	}
+
+	if err8 >= err4 {
+		t.Errorf("INT8 total error (%.6f) should be less than INT4 (%.6f)", err8, err4)
+	}
+}
+
+// === PER-CHANNEL VS PER-TENSOR ===
+
+func TestPerChannelBeatsPerTensorOnMixedScales(t *testing.T) {
+	// Matrix with rows at very different scales -- per-channel should win
+	weights := [][]float64{
+		{0.001, -0.002, 0.001, -0.001},
+		{10.0, -20.0, 15.0, -5.0},
+	}
+
+	deqTensor := DequantizeAbsmax(QuantizeAbsmaxInt8(weights))
+	deqChannel := DequantizePerChannel(QuantizePerChannelInt8(weights))
+
+	// Error on the small row
+	errTensor, errChannel := 0.0, 0.0
+	for j := range weights[0] {
+		errTensor += math.Abs(weights[0][j] - deqTensor[0][j])
+		errChannel += math.Abs(weights[0][j] - deqChannel[0][j])
+	}
+
+	if errChannel >= errTensor {
+		t.Errorf("Per-channel error (%.8f) should be less than per-tensor (%.8f) on mixed-scale matrix",
+			errChannel, errTensor)
+	}
+}
+
+// === FLOAT OPERATIONS ===
+
+func TestLinearFloat(t *testing.T) {
+	w := [][]float64{{1, 2}, {3, 4}}
+	x := []float64{1, 1}
+	y := LinearFloat(x, w)
+	if math.Abs(y[0]-3) > 1e-10 || math.Abs(y[1]-7) > 1e-10 {
+		t.Errorf("LinearFloat([1,1], [[1,2],[3,4]]) = %v, want [3, 7]", y)
+	}
+}
+
+func TestSoftmaxFloat(t *testing.T) {
+	logits := []float64{1, 2, 3}
+	probs := SoftmaxFloat(logits)
+
+	sum := 0.0
+	for _, p := range probs {
+		sum += p
+		if p < 0 || p > 1 {
+			t.Errorf("Probability out of range: %f", p)
+		}
+	}
+	if math.Abs(sum-1.0) > 1e-10 {
+		t.Errorf("Softmax sum = %f, want 1.0", sum)
+	}
+	// Probabilities should be monotonically increasing
+	if probs[0] >= probs[1] || probs[1] >= probs[2] {
+		t.Errorf("Softmax not monotonic: %v", probs)
+	}
+}
+
+func TestRMSNormFloat(t *testing.T) {
+	x := []float64{3, 4}
+	normed := RMSNormFloat(x)
+
+	// RMS = sqrt((9+16)/2) = sqrt(12.5) ≈ 3.536
+	// scale = 1/sqrt(12.5 + 1e-5) ≈ 0.2828
+	rms := math.Sqrt((9 + 16) / 2.0)
+	expected0 := 3.0 / rms
+	expected1 := 4.0 / rms
+	if math.Abs(normed[0]-expected0) > 1e-4 || math.Abs(normed[1]-expected1) > 1e-4 {
+		t.Errorf("RMSNormFloat([3,4]) = %v, want [%.4f, %.4f]", normed, expected0, expected1)
+	}
+}
+
+// === FLOAT GPT FORWARD ===
+
+func TestGPTForwardFloatOutputShape(t *testing.T) {
+	rng := rand.New(rand.NewPCG(42, 0))
+	vocabSize := 10
+	cfg := DefaultGPTConfig(vocabSize)
+	params := InitGPTParams(rng, cfg)
+	fp := ExtractFloatParams(params)
+
+	keys := make([][]float64Slice, cfg.NLayer)
+	values := make([][]float64Slice, cfg.NLayer)
+
+	logits := GPTForwardFloat(0, 0, &keys, &values, fp)
+	if len(logits) != vocabSize {
+		t.Errorf("logits length = %d, want %d", len(logits), vocabSize)
+	}
+}
+
+func TestGPTForwardFloatMatchesAutograd(t *testing.T) {
+	// Float forward should produce the same logits as Value-based forward
+	rng := rand.New(rand.NewPCG(42, 0))
+	vocabSize := 5
+	cfg := DefaultGPTConfig(vocabSize)
+	params := InitGPTParams(rng, cfg)
+	fp := ExtractFloatParams(params)
+
+	// Value-based forward
+	vKeys := make([][]*[]*Value, cfg.NLayer)
+	vValues := make([][]*[]*Value, cfg.NLayer)
+	vLogits := GPTForward(0, 0, &vKeys, &vValues, params)
+
+	// Float-based forward
+	fKeys := make([][]float64Slice, cfg.NLayer)
+	fValues := make([][]float64Slice, cfg.NLayer)
+	fLogits := GPTForwardFloat(0, 0, &fKeys, &fValues, fp)
+
+	for i := range vLogits {
+		if math.Abs(vLogits[i].Data-fLogits[i]) > 1e-10 {
+			t.Errorf("logit[%d]: Value=%.10f, Float=%.10f", i, vLogits[i].Data, fLogits[i])
+		}
+	}
+}
+
+// === EXTRACT AND EVAL ===
+
+func TestExtractFloatParams(t *testing.T) {
+	rng := rand.New(rand.NewPCG(42, 0))
+	cfg := DefaultGPTConfig(5)
+	params := InitGPTParams(rng, cfg)
+	fp := ExtractFloatParams(params)
+
+	if len(fp.Wte) != 5 || len(fp.Wte[0]) != 16 {
+		t.Errorf("Wte shape: [%d][%d], want [5][16]", len(fp.Wte), len(fp.Wte[0]))
+	}
+	// Values should match
+	for i := range params.Wte {
+		for j := range params.Wte[i] {
+			if params.Wte[i][j].Data != fp.Wte[i][j] {
+				t.Fatalf("Wte[%d][%d] mismatch", i, j)
+			}
+		}
+	}
+}
+
+func TestComputeModelSize(t *testing.T) {
+	rng := rand.New(rand.NewPCG(42, 0))
+	cfg := DefaultGPTConfig(27)
+	params := InitGPTParams(rng, cfg)
+	fp := ExtractFloatParams(params)
+
+	size32 := ComputeModelSize(fp, 32)
+	size8 := ComputeModelSize(fp, 8)
+	size4 := ComputeModelSize(fp, 4)
+
+	if size32 != size8*4 {
+		t.Errorf("size32 (%d) should be 4x size8 (%d)", size32, size8)
+	}
+	if size32 != size4*8 {
+		t.Errorf("size32 (%d) should be 8x size4 (%d)", size32, size4)
+	}
+}
+
+// === QUANTIZED MODEL EVALUATION ===
+
+func TestQuantizedModelLossFinite(t *testing.T) {
+	// Train a tiny model, quantize, verify loss is finite
+	docs := []string{"ab", "ba", "aa", "bb"}
+	rng := rand.New(rand.NewPCG(42, 0))
+	result := TrainGPT(docs, 20, rng, false)
+	fp := ExtractFloatParams(result.Params)
+
+	chars, charToIdx, bos := BuildVocab(docs)
+
+	for _, method := range []string{"int8-absmax", "int4-absmax", "int8-zeropoint", "int8-perchannel"} {
+		qfp := QuantizeAllParams(fp, method)
+		loss := EvalQuantLoss(qfp, docs, chars, charToIdx, bos)
+		if math.IsNaN(loss) || math.IsInf(loss, 0) {
+			t.Errorf("%s: loss is %f, expected finite", method, loss)
+		}
+	}
+}
+
+func TestQuantizedLossCloseToBaseline(t *testing.T) {
+	// INT8 quantized loss should be within 50% of baseline for a trained model
+	docs := []string{"abc", "bca", "cab", "abc", "bca"}
+	rng := rand.New(rand.NewPCG(42, 0))
+	result := TrainGPT(docs, 50, rng, false)
+	fp := ExtractFloatParams(result.Params)
+
+	chars, charToIdx, bos := BuildVocab(docs)
+	baselineLoss := EvalQuantLoss(fp, docs, chars, charToIdx, bos)
+
+	qfp := QuantizeAllParams(fp, "int8-absmax")
+	qLoss := EvalQuantLoss(qfp, docs, chars, charToIdx, bos)
+
+	ratio := qLoss / baselineLoss
+	if ratio > 1.5 || ratio < 0.5 {
+		t.Errorf("INT8 loss (%.4f) diverges too far from baseline (%.4f), ratio=%.2f",
+			qLoss, baselineLoss, ratio)
+	}
+	t.Logf("Baseline: %.4f, INT8: %.4f, ratio: %.2f", baselineLoss, qLoss, ratio)
+}
+
+// === BENCHMARKS ===
+
+func BenchmarkQuantizeAbsmaxInt8(b *testing.B) {
+	rng := rand.New(rand.NewPCG(42, 0))
+	weights := make([][]float64, 64)
+	for i := range weights {
+		weights[i] = make([]float64, 16)
+		for j := range weights[i] {
+			weights[i][j] = rng.NormFloat64() * 0.1
+		}
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		QuantizeAbsmaxInt8(weights)
+	}
+}
+
+func BenchmarkGPTForwardFloat(b *testing.B) {
+	rng := rand.New(rand.NewPCG(42, 0))
+	cfg := DefaultGPTConfig(10)
+	params := InitGPTParams(rng, cfg)
+	fp := ExtractFloatParams(params)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		keys := make([][]float64Slice, cfg.NLayer)
+		values := make([][]float64Slice, cfg.NLayer)
+		GPTForwardFloat(0, 0, &keys, &values, fp)
+	}
+}


### PR DESCRIPTION
## Summary
- Port of `microquant.py` from no-magic: absmax int8/int4, zeropoint int8, per-channel int8 quantization with dequantization roundtrip
- Float-based GPT forward pass (`GPTForwardFloat`) for inference without autograd overhead
- `QuantizeAllParams`, `ComputeRoundtripError`, `ComputeModelSize`, `EvalQuantLoss`, `GenerateQuantSample` utilities
- 17 tests + 2 benchmarks, `//go:build research` tagged, zero dependencies