### PR TITLE
Add decoding strategies port (microbeam.go)

### DIFF
--- a/research/ml/README.md
+++ b/research/ml/README.md
@@ -17,6 +17,7 @@ All files use the `research` build tag and are excluded from default compilation
 | Scalar Autograd | `value.go` | Done |
 | GPT (char-level) | `microgpt.go` | Done |
 | Quantization | `microquant.go` | Done |
+| Decoding Strategies | `microbeam.go` | Done |
 
 ## Run
 
@@ -25,7 +26,7 @@ go test -tags research -v ./research/ml/
 go test -tags research -bench=. -benchmem ./research/ml/
 ```
 
-To run demos interactively, call `ml.RunMicrotokenizer()`, `ml.RunMicroflash()`, `ml.RunMicrogpt()`, or `ml.RunMicroquant()` from a tagged main or test.
+To run demos interactively, call `ml.RunMicrotokenizer()`, `ml.RunMicroflash()`, `ml.RunMicrogpt()`, `ml.RunMicroquant()`, or `ml.RunMicrobeam()` from a tagged main or test.
 
 ## Design
 

--- a/research/ml/microbeam.go
+++ b/research/ml/microbeam.go
@@ -1,0 +1,893 @@
+//go:build research
+
+// Beyond greedy: six decoding strategies for language model text generation, from deterministic
+// argmax to speculative decoding with a draft-verify two-model pipeline.
+//
+// Reference: Leviathan et al., "Fast Inference from Transformers via Speculative
+// Decoding" (2023). https://arxiv.org/abs/2211.17192
+// Also: Holtzman et al., "The Curious Case of Neural Text Degeneration" (2019).
+// https://arxiv.org/abs/1904.09751 (nucleus/top-p sampling)
+//
+// Port of microbeam.py from mathews-tom/no-magic to Go.
+// AGPL-3.0 -- see LICENSE in repo root.
+package ml
+
+import (
+	"fmt"
+	"math"
+	"math/rand/v2"
+	"sort"
+)
+
+// === CONSTANTS AND HYPERPARAMETERS ===
+
+// Target model (larger, ~4,200 params) and draft model (smaller, ~1,300 params).
+// Both share vocabulary and block_size -- required for speculative decoding since
+// the draft model must produce tokens the target model can verify.
+const (
+	beamTargetNEmbd  = 16
+	beamTargetNHead  = 4
+	beamTargetNLayer = 1
+	beamDraftNEmbd   = 8
+	beamDraftNHead   = 2
+	beamDraftNLayer  = 1
+	beamBlockSize    = 16
+
+	// Training
+	beamLR          = 0.01
+	beamBeta1       = 0.85
+	beamBeta2       = 0.99
+	beamEpsAdam     = 1e-8
+	beamTargetSteps = 700
+	beamDraftSteps  = 500
+)
+
+// Signpost: production speculative decoding pairs a 70B target with a 7B draft.
+// Our 4,200 / 1,300 param ratio preserves the algorithmic structure. Real speedups
+// come from GPU parallelism during the verify pass -- here we measure acceptance
+// rate, which is the hardware-independent metric that matters.
+
+// === BEAM CONFIG ===
+
+// BeamConfig holds model dimensions for a target or draft model.
+type BeamConfig struct {
+	NEmbd   int
+	NHead   int
+	NLayer  int
+	HeadDim int
+}
+
+// TargetBeamConfig returns the target (larger) model config.
+func TargetBeamConfig() BeamConfig {
+	return BeamConfig{
+		NEmbd:   beamTargetNEmbd,
+		NHead:   beamTargetNHead,
+		NLayer:  beamTargetNLayer,
+		HeadDim: beamTargetNEmbd / beamTargetNHead,
+	}
+}
+
+// DraftBeamConfig returns the draft (smaller) model config.
+func DraftBeamConfig() BeamConfig {
+	return BeamConfig{
+		NEmbd:   beamDraftNEmbd,
+		NHead:   beamDraftNHead,
+		NLayer:  beamDraftNLayer,
+		HeadDim: beamDraftNEmbd / beamDraftNHead,
+	}
+}
+
+// ToGPTConfig converts a BeamConfig to a GPTConfig for a given vocab size.
+func (bc BeamConfig) ToGPTConfig(vocabSize int) GPTConfig {
+	return GPTConfig{
+		NEmbd:     bc.NEmbd,
+		NHead:     bc.NHead,
+		NLayer:    bc.NLayer,
+		BlockSize: beamBlockSize,
+		VocabSize: vocabSize,
+		InitStd:   gptInitStd,
+	}
+}
+
+// === TRAINING ===
+// Uses the existing autograd engine (value.go) and GPT architecture (microgpt.go).
+// The only difference from TrainGPT is configurable model dimensions.
+
+// TrainBeamModel trains a GPT model with the given config and training parameters.
+// Returns the trained params and final loss.
+func TrainBeamModel(docs []string, chars []rune, charToIdx map[rune]int, bos int,
+	bc BeamConfig, steps int, rng *rand.Rand, verbose bool) *GPTTrainResult {
+
+	vocabSize := len(chars) + 1
+	cfg := bc.ToGPTConfig(vocabSize)
+
+	params := InitGPTParams(rng, cfg)
+	paramList := params.AllParams()
+	if verbose {
+		fmt.Printf("Parameters: %d\n", len(paramList))
+	}
+
+	adam := NewAdamState(len(paramList))
+
+	shuffled := make([]string, len(docs))
+	copy(shuffled, docs)
+	rng.Shuffle(len(shuffled), func(i, j int) { shuffled[i], shuffled[j] = shuffled[j], shuffled[i] })
+
+	lossHistory := make([]float64, steps)
+	var lastLoss float64
+
+	for step := 0; step < steps; step++ {
+		doc := shuffled[step%len(shuffled)]
+		tokens := Tokenize(doc, charToIdx, bos)
+
+		seqLen := cfg.BlockSize
+		if len(tokens)-1 < seqLen {
+			seqLen = len(tokens) - 1
+		}
+
+		keys := make([][]*[]*Value, cfg.NLayer)
+		values := make([][]*[]*Value, cfg.NLayer)
+
+		losses := make([]*Value, seqLen)
+		for pos := 0; pos < seqLen; pos++ {
+			logits := GPTForward(tokens[pos], pos, &keys, &values, params)
+			probs := VSoftmax(logits)
+			losses[pos] = probs[tokens[pos+1]].SafeLog().Neg()
+		}
+
+		loss := VSum(losses).DivScalar(float64(seqLen))
+		loss.Backward()
+
+		lrT := beamLR * (1.0 - float64(step)/float64(steps))
+		for i, p := range paramList {
+			g := p.Grad
+			adam.M[i] = beamBeta1*adam.M[i] + (1-beamBeta1)*g
+			adam.V[i] = beamBeta2*adam.V[i] + (1-beamBeta2)*g*g
+			mHat := adam.M[i] / (1 - math.Pow(beamBeta1, float64(step+1)))
+			vHat := adam.V[i] / (1 - math.Pow(beamBeta2, float64(step+1)))
+			p.Data -= lrT * mHat / (math.Sqrt(vHat) + beamEpsAdam)
+			p.Grad = 0.0
+		}
+
+		lastLoss = loss.Data
+		lossHistory[step] = lastLoss
+
+		if verbose && ((step+1)%100 == 0 || step == 0) {
+			fmt.Printf("  step %4d/%4d | loss: %.4f\n", step+1, steps, lastLoss)
+		}
+	}
+
+	if verbose {
+		fmt.Printf("  Final loss: %.4f\n\n", lastLoss)
+	}
+
+	return &GPTTrainResult{
+		Params:      params,
+		FinalLoss:   lastLoss,
+		LossHistory: lossHistory,
+	}
+}
+
+// === FLOAT FORWARD PASS HELPERS ===
+// After training, weights are extracted as plain floats. All six decoding
+// strategies operate here -- no autograd overhead, enabling clean comparison.
+
+// BeamKV is a KV cache for float-based inference: [nLayer] of {k, v} lists.
+type BeamKV = [][]float64Slice
+
+// MakeBeamKV creates a fresh empty KV cache for nLayer layers.
+func MakeBeamKV(nLayer int) BeamKV {
+	return make(BeamKV, nLayer)
+}
+
+// CloneBeamKV deep-copies a KV cache so beam branches don't share mutable state.
+func CloneBeamKV(cache BeamKV) BeamKV {
+	out := make(BeamKV, len(cache))
+	for li, layer := range cache {
+		out[li] = make([]float64Slice, len(layer))
+		for t, vec := range layer {
+			cp := make([]float64, len(vec))
+			copy(cp, vec)
+			out[li][t] = cp
+		}
+	}
+	return out
+}
+
+// beamForward runs the float GPT forward pass, reusing GPTForwardFloat from microquant.go.
+// Note: GPTForwardFloat uses a KV cache where keys and values are interleaved in a single
+// [][]float64Slice per layer. For beam search we need separate key/value caches since
+// CloneBeamKV needs to deep-copy them independently for each beam branch.
+//
+// We use a lightweight wrapper that manages two parallel caches (keys + values) and calls
+// the same linear/softmax/rmsnorm primitives.
+func beamForward(tokenID, posID int, keys, values *BeamKV, fp *FloatGPTParams) []float64 {
+	cfg := fp.Config
+	headDim := cfg.HeadDim()
+
+	tokEmb := fp.Wte[tokenID]
+	posEmb := fp.Wpe[posID]
+	x := make([]float64, cfg.NEmbd)
+	for i := range x {
+		x[i] = tokEmb[i] + posEmb[i]
+	}
+	x = RMSNormFloat(x)
+
+	for li := range fp.Layers {
+		layer := &fp.Layers[li]
+		xResidual := make([]float64, len(x))
+		copy(xResidual, x)
+
+		x = RMSNormFloat(x)
+		q := LinearFloat(x, layer.AttnWQ)
+		k := LinearFloat(x, layer.AttnWK)
+		v := LinearFloat(x, layer.AttnWV)
+
+		(*keys)[li] = append((*keys)[li], k)
+		(*values)[li] = append((*values)[li], v)
+
+		xAttn := make([]float64, 0, cfg.NEmbd)
+		for head := 0; head < cfg.NHead; head++ {
+			hs := head * headDim
+			qHead := q[hs : hs+headDim]
+			cachedK := (*keys)[li]
+			cachedV := (*values)[li]
+			seqLen := len(cachedK)
+
+			scale := 1.0 / math.Sqrt(float64(headDim))
+			attnLogits := make([]float64, seqLen)
+			for t := 0; t < seqLen; t++ {
+				dot := 0.0
+				for j := 0; j < headDim; j++ {
+					dot += qHead[j] * cachedK[t][hs+j]
+				}
+				attnLogits[t] = dot * scale
+			}
+
+			attnWeights := SoftmaxFloat(attnLogits)
+
+			headOutput := make([]float64, headDim)
+			for j := 0; j < headDim; j++ {
+				s := 0.0
+				for t := 0; t < seqLen; t++ {
+					s += attnWeights[t] * cachedV[t][hs+j]
+				}
+				headOutput[j] = s
+			}
+			xAttn = append(xAttn, headOutput...)
+		}
+
+		x = LinearFloat(xAttn, layer.AttnWO)
+		for i := range x {
+			x[i] += xResidual[i]
+		}
+		xResidual = make([]float64, len(x))
+		copy(xResidual, x)
+
+		x = RMSNormFloat(x)
+		x = LinearFloat(x, layer.MLPFC1)
+		for i := range x {
+			if x[i] < 0 {
+				x[i] = 0
+			}
+		}
+		x = LinearFloat(x, layer.MLPFC2)
+		for i := range x {
+			x[i] += xResidual[i]
+		}
+	}
+
+	return LinearFloat(x, fp.LMHead)
+}
+
+// feedPrompt processes prompt tokens through the model, returning (keys, values, lastLogits).
+func feedPrompt(prompt []int, fp *FloatGPTParams) (BeamKV, BeamKV, []float64) {
+	keys := MakeBeamKV(fp.Config.NLayer)
+	values := MakeBeamKV(fp.Config.NLayer)
+	var logits []float64
+	for i, tok := range prompt {
+		logits = beamForward(tok, i, &keys, &values, fp)
+	}
+	return keys, values, logits
+}
+
+// === DECODING STRATEGIES ===
+// Each strategy takes a prompt, weights, and config, returns generated tokens
+// plus total log-probability. They differ ONLY in token selection.
+
+// DecodeResult holds the output of a decoding strategy.
+type DecodeResult struct {
+	Tokens   []int
+	LogProb  float64
+	Proposed int // speculative decoding: total draft tokens proposed
+	Accepted int // speculative decoding: total draft tokens accepted
+}
+
+// DecodeGreedy always picks the highest-probability token. Deterministic.
+//
+// Simple but suboptimal: commits to the locally best choice at each step,
+// which can miss globally better sequences. Greedy decoding is optimal only
+// when the model is perfectly calibrated (it never is).
+func DecodeGreedy(prompt []int, fp *FloatGPTParams, maxLen int) DecodeResult {
+	keys, values, logits := feedPrompt(prompt, fp)
+	var gen []int
+	lp := 0.0
+	for i := 0; i < maxLen; i++ {
+		pos := len(prompt) + len(gen)
+		if pos >= fp.Config.BlockSize {
+			break
+		}
+		probs := SoftmaxFloat(logits)
+		tok := argmax(probs)
+		if tok == fp.Config.VocabSize-1 { // BOS = vocabSize-1
+			break
+		}
+		lp += math.Log(math.Max(probs[tok], 1e-10))
+		gen = append(gen, tok)
+		logits = beamForward(tok, pos, &keys, &values, fp)
+	}
+	return DecodeResult{Tokens: gen, LogProb: lp}
+}
+
+// DecodeTemperature scales logits by temperature before sampling.
+//
+// Temperature reshapes the probability distribution without changing its
+// ranking. T < 1 sharpens (more deterministic), T > 1 flattens (more random).
+// The math: softmax(logits/T) concentrates mass on the mode as T -> 0
+// and approaches uniform as T -> inf.
+func DecodeTemperature(prompt []int, fp *FloatGPTParams, maxLen int,
+	temperature float64, rng *rand.Rand) DecodeResult {
+
+	keys, values, logits := feedPrompt(prompt, fp)
+	var gen []int
+	lp := 0.0
+	for i := 0; i < maxLen; i++ {
+		pos := len(prompt) + len(gen)
+		if pos >= fp.Config.BlockSize {
+			break
+		}
+		scaled := make([]float64, len(logits))
+		for j, l := range logits {
+			scaled[j] = l / temperature
+		}
+		probs := SoftmaxFloat(scaled)
+		tok := weightedSampleFloat(probs, rng)
+		if tok == fp.Config.VocabSize-1 {
+			break
+		}
+		lp += math.Log(math.Max(probs[tok], 1e-10))
+		gen = append(gen, tok)
+		logits = beamForward(tok, pos, &keys, &values, fp)
+	}
+	return DecodeResult{Tokens: gen, LogProb: lp}
+}
+
+// DecodeTopK only considers the k most likely tokens, zeroes out the rest.
+//
+// Prevents sampling from the long tail of unlikely tokens. The cutoff is
+// fixed regardless of the model's confidence -- this rigidity is top-k's
+// weakness compared to top-p.
+func DecodeTopK(prompt []int, fp *FloatGPTParams, maxLen, k int,
+	rng *rand.Rand) DecodeResult {
+
+	keys, values, logits := feedPrompt(prompt, fp)
+	bos := fp.Config.VocabSize - 1
+	var gen []int
+	lp := 0.0
+	for i := 0; i < maxLen; i++ {
+		pos := len(prompt) + len(gen)
+		if pos >= fp.Config.BlockSize {
+			break
+		}
+		probs := SoftmaxFloat(logits)
+		ranked := argsortDesc(probs)
+		topSet := make(map[int]bool, k)
+		for j := 0; j < k && j < len(ranked); j++ {
+			topSet[ranked[j]] = true
+		}
+		filt := make([]float64, len(probs))
+		total := 0.0
+		for j := range probs {
+			if topSet[j] {
+				filt[j] = probs[j]
+				total += probs[j]
+			}
+		}
+		for j := range filt {
+			filt[j] /= total
+		}
+		tok := weightedSampleFloat(filt, rng)
+		if tok == bos {
+			break
+		}
+		// Log-prob from the ORIGINAL distribution -- measures model confidence
+		lp += math.Log(math.Max(probs[tok], 1e-10))
+		gen = append(gen, tok)
+		logits = beamForward(tok, pos, &keys, &values, fp)
+	}
+	return DecodeResult{Tokens: gen, LogProb: lp}
+}
+
+// DecodeTopP includes tokens until cumulative probability exceeds p (nucleus sampling).
+//
+// Adaptive: for confident predictions (one token at 95%), only that token
+// is considered. For uncertain predictions, many tokens enter the nucleus.
+// This adaptivity is why top-p often outperforms fixed top-k -- the model's
+// own confidence determines the effective vocabulary size at each step.
+func DecodeTopP(prompt []int, fp *FloatGPTParams, maxLen int,
+	p float64, rng *rand.Rand) DecodeResult {
+
+	keys, values, logits := feedPrompt(prompt, fp)
+	bos := fp.Config.VocabSize - 1
+	var gen []int
+	lp := 0.0
+	for i := 0; i < maxLen; i++ {
+		pos := len(prompt) + len(gen)
+		if pos >= fp.Config.BlockSize {
+			break
+		}
+		probs := SoftmaxFloat(logits)
+		ranked := argsortDesc(probs)
+		cumsum := 0.0
+		nucleus := make(map[int]bool)
+		for _, idx := range ranked {
+			nucleus[idx] = true
+			cumsum += probs[idx]
+			if cumsum >= p {
+				break
+			}
+		}
+		filt := make([]float64, len(probs))
+		total := 0.0
+		for j := range probs {
+			if nucleus[j] {
+				filt[j] = probs[j]
+				total += probs[j]
+			}
+		}
+		for j := range filt {
+			filt[j] /= total
+		}
+		tok := weightedSampleFloat(filt, rng)
+		if tok == bos {
+			break
+		}
+		lp += math.Log(math.Max(probs[tok], 1e-10))
+		gen = append(gen, tok)
+		logits = beamForward(tok, pos, &keys, &values, fp)
+	}
+	return DecodeResult{Tokens: gen, LogProb: lp}
+}
+
+// DecodeBeam maintains top-B candidate sequences, expanding and pruning at each step.
+//
+// Finds higher log-probability sequences than greedy by exploring multiple
+// paths simultaneously. Beam search is NOT sampling -- it is a deterministic
+// search algorithm. Two runs with the same input produce identical output.
+// The key tradeoff: beam_width * cost_per_step compute for potentially much
+// better global solutions. Used heavily in machine translation.
+func DecodeBeam(prompt []int, fp *FloatGPTParams, maxLen, beamWidth int) DecodeResult {
+	bos := fp.Config.VocabSize - 1
+
+	// Each beam: (cumLogProb, tokens, keys, values, pendingLogits)
+	type beam struct {
+		logProb float64
+		tokens  []int
+		keys    BeamKV
+		values  BeamKV
+		logits  []float64
+	}
+
+	initKeys, initValues, initLogits := feedPrompt(prompt, fp)
+	beams := []beam{{
+		logProb: 0.0,
+		tokens:  nil,
+		keys:    CloneBeamKV(initKeys),
+		values:  CloneBeamKV(initValues),
+		logits:  initLogits,
+	}}
+
+	type completed struct {
+		logProb float64
+		tokens  []int
+	}
+	var done []completed
+
+	for step := 0; step < maxLen; step++ {
+		var candidates []beam
+		for _, b := range beams {
+			pos := len(prompt) + len(b.tokens)
+			if pos >= fp.Config.BlockSize {
+				done = append(done, completed{b.logProb, b.tokens})
+				continue
+			}
+			probs := SoftmaxFloat(b.logits)
+			ranked := argsortDesc(probs)
+			for _, idx := range ranked[:min(beamWidth, len(ranked))] {
+				tokenLP := math.Log(math.Max(probs[idx], 1e-10))
+				if idx == bos {
+					done = append(done, completed{b.logProb + tokenLP, b.tokens})
+					continue
+				}
+				// Each expansion gets its own KV cache copy (beams diverge)
+				newKeys := CloneBeamKV(b.keys)
+				newValues := CloneBeamKV(b.values)
+				newLogits := beamForward(idx, pos, &newKeys, &newValues, fp)
+				newToks := make([]int, len(b.tokens)+1)
+				copy(newToks, b.tokens)
+				newToks[len(b.tokens)] = idx
+				candidates = append(candidates, beam{
+					logProb: b.logProb + tokenLP,
+					tokens:  newToks,
+					keys:    newKeys,
+					values:  newValues,
+					logits:  newLogits,
+				})
+			}
+		}
+		if len(candidates) == 0 {
+			break
+		}
+		// Prune: keep only top beamWidth by cumulative log-prob
+		sort.Slice(candidates, func(i, j int) bool {
+			return candidates[i].logProb > candidates[j].logProb
+		})
+		if len(candidates) > beamWidth {
+			candidates = candidates[:beamWidth]
+		}
+		beams = candidates
+	}
+
+	// Collect all results (completed + remaining beams)
+	for _, b := range beams {
+		done = append(done, completed{b.logProb, b.tokens})
+	}
+	if len(done) == 0 {
+		return DecodeResult{}
+	}
+	best := done[0]
+	for _, c := range done[1:] {
+		if c.logProb > best.logProb {
+			best = c
+		}
+	}
+	return DecodeResult{Tokens: best.tokens, LogProb: best.logProb}
+}
+
+// DecodeSpeculative uses a draft model to generate k tokens, then the target model verifies.
+//
+// The key insight: verifying k tokens with the target model costs roughly
+// the same as generating 1 token (on a GPU, k forward passes batch into one).
+// If the draft tokens match the target's distribution, we get ~k tokens per
+// target verification -- a significant speedup.
+//
+// Acceptance (Leviathan et al.): accept each draft token with probability
+// min(1, p_target/p_draft). On rejection, resample from max(0, p_target -
+// p_draft) and discard subsequent drafts. This is lossless: the output
+// distribution exactly matches the target model.
+//
+// Returns DecodeResult with Proposed and Accepted counts.
+func DecodeSpeculative(prompt []int, targetFP, draftFP *FloatGPTParams,
+	maxLen, draftK int, rng *rand.Rand) DecodeResult {
+
+	bos := targetFP.Config.VocabSize - 1
+
+	tKeys, tValues, tLogits := feedPrompt(prompt, targetFP)
+	dKeys, dValues, dLogits := feedPrompt(prompt, draftFP)
+
+	var gen []int
+	lp := 0.0
+	totalProposed := 0
+	totalAccepted := 0
+
+	for len(gen) < maxLen {
+		cur := len(prompt) + len(gen)
+		remaining := draftK
+		if maxLen-len(gen) < remaining {
+			remaining = maxLen - len(gen)
+		}
+		if cur >= targetFP.Config.BlockSize || remaining <= 0 {
+			break
+		}
+
+		// Phase 1: Draft model proposes k tokens greedily (fast, small model)
+		var draftToks []int
+		var draftProbs [][]float64
+		tmpDKeys := CloneBeamKV(dKeys)
+		tmpDValues := CloneBeamKV(dValues)
+		tmpDLogits := make([]float64, len(dLogits))
+		copy(tmpDLogits, dLogits)
+
+		for di := 0; di < remaining; di++ {
+			pos := cur + di
+			if pos >= draftFP.Config.BlockSize {
+				break
+			}
+			dp := SoftmaxFloat(tmpDLogits)
+			draftProbs = append(draftProbs, dp)
+			dtok := argmax(dp)
+			if dtok == bos {
+				break
+			}
+			draftToks = append(draftToks, dtok)
+			tmpDLogits = beamForward(dtok, pos, &tmpDKeys, &tmpDValues, draftFP)
+		}
+
+		if len(draftToks) == 0 {
+			// Draft produced BOS -- fall back to one target greedy step
+			tp := SoftmaxFloat(tLogits)
+			ttok := argmax(tp)
+			if ttok == bos {
+				break
+			}
+			lp += math.Log(math.Max(tp[ttok], 1e-10))
+			gen = append(gen, ttok)
+			tLogits = beamForward(ttok, cur, &tKeys, &tValues, targetFP)
+			dLogits = beamForward(ttok, cur, &dKeys, &dValues, draftFP)
+			continue
+		}
+
+		totalProposed += len(draftToks)
+
+		// Phase 2: Target model verifies each draft token
+		// On GPU this would be one batched forward pass. The acceptance logic is
+		// identical to the parallel version regardless of serial/parallel execution.
+		var accepted []int
+		tmpTKeys := CloneBeamKV(tKeys)
+		tmpTValues := CloneBeamKV(tValues)
+		tmpTLogits := make([]float64, len(tLogits))
+		copy(tmpTLogits, tLogits)
+
+		for vi := 0; vi < len(draftToks); vi++ {
+			tp := SoftmaxFloat(tmpTLogits)
+			dp := draftProbs[vi]
+			dtok := draftToks[vi]
+			// Rejection sampling: accept with p = min(1, p_target/p_draft)
+			ratio := math.Min(1.0, tp[dtok]/math.Max(dp[dtok], 1e-10))
+			if rng.Float64() < ratio {
+				accepted = append(accepted, dtok)
+				lp += math.Log(math.Max(tp[dtok], 1e-10))
+				tmpTLogits = beamForward(dtok, cur+vi, &tmpTKeys, &tmpTValues, targetFP)
+			} else {
+				// Reject: resample from max(0, p_target - p_draft)
+				adj := make([]float64, len(tp))
+				adjSum := 0.0
+				for j := range tp {
+					adj[j] = math.Max(0.0, tp[j]-dp[j])
+					adjSum += adj[j]
+				}
+				var rtok int
+				if adjSum > 0 {
+					for j := range adj {
+						adj[j] /= adjSum
+					}
+					rtok = weightedSampleFloat(adj, rng)
+				} else {
+					rtok = weightedSampleFloat(tp, rng)
+				}
+				if rtok != bos {
+					accepted = append(accepted, rtok)
+					lp += math.Log(math.Max(tp[rtok], 1e-10))
+					beamForward(rtok, cur+vi, &tmpTKeys, &tmpTValues, targetFP)
+				}
+				break // Discard all remaining draft tokens after rejection
+			}
+		}
+
+		totalAccepted += len(accepted)
+
+		// Commit accepted tokens to both real KV caches
+		for ai, atok := range accepted {
+			tLogits = beamForward(atok, cur+ai, &tKeys, &tValues, targetFP)
+			dLogits = beamForward(atok, cur+ai, &dKeys, &dValues, draftFP)
+			gen = append(gen, atok)
+		}
+
+		if len(accepted) == 0 {
+			tp := SoftmaxFloat(tLogits)
+			ttok := argmax(tp)
+			if ttok == bos {
+				break
+			}
+			lp += math.Log(math.Max(tp[ttok], 1e-10))
+			gen = append(gen, ttok)
+			tLogits = beamForward(ttok, cur, &tKeys, &tValues, targetFP)
+			dLogits = beamForward(ttok, cur, &dKeys, &dValues, draftFP)
+		}
+	}
+
+	return DecodeResult{
+		Tokens:   gen,
+		LogProb:  lp,
+		Proposed: totalProposed,
+		Accepted: totalAccepted,
+	}
+}
+
+// === DEMO ===
+
+// RunMicrobeam trains target and draft models, then compares all 6 decoding strategies.
+func RunMicrobeam() {
+	fmt.Println("=== MicroBeam: Decoding Strategies Comparison ===")
+	fmt.Println()
+
+	// Small built-in corpus
+	docs := []string{
+		"emma", "olivia", "ava", "sophia", "isabella",
+		"mia", "charlotte", "amelia", "harper", "evelyn",
+		"abigail", "emily", "elizabeth", "mila", "ella",
+		"avery", "sofia", "camila", "aria", "scarlett",
+		"victoria", "madison", "luna", "grace", "chloe",
+		"penelope", "layla", "riley", "zoey", "nora",
+		"lily", "eleanor", "hannah", "lillian", "addison",
+		"aubrey", "ellie", "stella", "natalie", "zoe",
+		"leah", "hazel", "violet", "aurora", "savannah",
+		"audrey", "brooklyn", "bella", "claire", "skylar",
+	}
+
+	chars, charToIdx, bos := BuildVocab(docs)
+	vocabSize := len(chars) + 1
+	_ = vocabSize
+
+	rng := rand.New(rand.NewPCG(42, 0))
+
+	// Train target model (larger)
+	fmt.Printf("=== Training Target Model (n_embd=%d, n_layer=%d) ===\n",
+		beamTargetNEmbd, beamTargetNLayer)
+	targetResult := TrainBeamModel(docs, chars, charToIdx, bos,
+		TargetBeamConfig(), beamTargetSteps, rng, true)
+
+	// Train draft model (smaller)
+	fmt.Printf("=== Training Draft Model (n_embd=%d, n_layer=%d) ===\n",
+		beamDraftNEmbd, beamDraftNLayer)
+	draftResult := TrainBeamModel(docs, chars, charToIdx, bos,
+		DraftBeamConfig(), beamDraftSteps, rng, true)
+
+	// Extract float weights for inference
+	targetFP := ExtractFloatParams(targetResult.Params)
+	draftFP := ExtractFloatParams(draftResult.Params)
+
+	// Token-to-string helper
+	tok2str := func(toks []int) string {
+		var out []rune
+		for _, t := range toks {
+			if t >= 0 && t < len(chars) {
+				out = append(out, chars[t])
+			}
+		}
+		return string(out)
+	}
+
+	// === DECODING STRATEGIES COMPARISON ===
+	fmt.Println("=== Decoding Strategies Comparison ===")
+
+	type promptEntry struct {
+		label string
+		toks  []int
+	}
+	prompts := []promptEntry{
+		{"a", []int{bos, charToIdx['a']}},
+		{"m", []int{bos, charToIdx['m']}},
+	}
+
+	for _, pe := range prompts {
+		fmt.Printf("\nPrompt: \"%s\" (BOS + '%s')\n\n", pe.label, pe.label)
+		fmt.Printf("%-22s %-16s %10s %12s\n", "Strategy", "Output", "Log-Prob", "Tokens/Step")
+		fmt.Println("--------------------------------------------------------------")
+
+		g := DecodeGreedy(pe.toks, targetFP, 12)
+		fmt.Printf("%-22s %-16s %10.2f %12s\n", "Greedy", tok2str(g.Tokens), g.LogProb, "1.0")
+
+		t := DecodeTemperature(pe.toks, targetFP, 12, 0.8, rng)
+		fmt.Printf("%-22s %-16s %10.2f %12s\n", "Temperature (0.8)", tok2str(t.Tokens), t.LogProb, "1.0")
+
+		k := DecodeTopK(pe.toks, targetFP, 12, 5, rng)
+		fmt.Printf("%-22s %-16s %10.2f %12s\n", "Top-k (k=5)", tok2str(k.Tokens), k.LogProb, "1.0")
+
+		p := DecodeTopP(pe.toks, targetFP, 12, 0.9, rng)
+		fmt.Printf("%-22s %-16s %10.2f %12s\n", "Top-p (p=0.9)", tok2str(p.Tokens), p.LogProb, "1.0")
+
+		b := DecodeBeam(pe.toks, targetFP, 12, 3)
+		fmt.Printf("%-22s %-16s %10.2f %12s\n", "Beam (width=3)", tok2str(b.Tokens), b.LogProb, "1.0")
+
+		s := DecodeSpeculative(pe.toks, targetFP, draftFP, 12, 4, rng)
+		tps := 1.0
+		if s.Proposed > 0 {
+			nRounds := float64(s.Proposed) / 4.0
+			tps = float64(s.Accepted) / math.Max(nRounds, 1.0)
+		}
+		fmt.Printf("%-22s %-16s %10.2f %12.1f\n", "Speculative (k=4)", tok2str(s.Tokens), s.LogProb, tps)
+	}
+
+	// === DIVERSITY ANALYSIS ===
+	fmt.Println("\n=== Diversity Analysis ===")
+	fmt.Println("Generated 20 names with each strategy:")
+	fmt.Println()
+	nSamp := 20
+	seeds := []rune("abcdefghijklmnopqrst")
+
+	type stratEntry struct {
+		name string
+		fn   func([]int) DecodeResult
+	}
+	strats := []stratEntry{
+		{"Greedy", func(pt []int) DecodeResult { return DecodeGreedy(pt, targetFP, 12) }},
+		{"Temperature (0.8)", func(pt []int) DecodeResult { return DecodeTemperature(pt, targetFP, 12, 0.8, rng) }},
+		{"Top-k (k=5)", func(pt []int) DecodeResult { return DecodeTopK(pt, targetFP, 12, 5, rng) }},
+		{"Top-p (p=0.9)", func(pt []int) DecodeResult { return DecodeTopP(pt, targetFP, 12, 0.9, rng) }},
+		{"Beam (width=3)", func(pt []int) DecodeResult { return DecodeBeam(pt, targetFP, 12, 3) }},
+	}
+
+	fmt.Printf("%-22s %13s %11s %13s\n", "Strategy", "Unique Names", "Avg Length", "Avg Log-Prob")
+	fmt.Println("--------------------------------------------------------------")
+	for _, se := range strats {
+		names := make([]string, nSamp)
+		lps := make([]float64, nSamp)
+		for i := 0; i < nSamp; i++ {
+			pt := []int{bos, charToIdx[seeds[i]]}
+			r := se.fn(pt)
+			names[i] = tok2str(r.Tokens)
+			lps[i] = r.LogProb
+		}
+		unique := map[string]bool{}
+		totalLen := 0
+		for _, n := range names {
+			unique[n] = true
+			totalLen += len(n)
+		}
+		avgLP := 0.0
+		for _, l := range lps {
+			avgLP += l
+		}
+		avgLP /= float64(nSamp)
+		fmt.Printf("%-22s %13d %11.1f %13.2f\n",
+			se.name, len(unique), float64(totalLen)/float64(nSamp), avgLP)
+	}
+
+	// === SPECULATIVE DECODING STATS ===
+	fmt.Println("\n=== Speculative Decoding Stats ===")
+	totProp := 0
+	totAcc := 0
+	for i := 0; i < nSamp; i++ {
+		pt := []int{bos, charToIdx[seeds[i]]}
+		r := DecodeSpeculative(pt, targetFP, draftFP, 12, 4, rng)
+		totProp += r.Proposed
+		totAcc += r.Accepted
+	}
+	accRate := 100.0 * float64(totAcc) / math.Max(float64(totProp), 1.0)
+	nRounds := float64(totProp) / 4.0
+	toksPerRound := float64(totAcc) / math.Max(nRounds, 1.0)
+	fmt.Printf("Draft tokens proposed per step: 4\n")
+	fmt.Printf("Total proposed: %d | Total accepted: %d\n", totProp, totAcc)
+	fmt.Printf("Average acceptance rate: %.1f%%\n", accRate)
+	fmt.Printf("Average tokens accepted per target verify pass: %.1f\n", toksPerRound)
+	// Signpost: in production with a well-matched draft model, acceptance rates of
+	// 70-90% are common. The real GPU speedup comes from batching the k verification
+	// forward passes into a single kernel launch -- our scalar Go cannot show that
+	// parallelism, but the acceptance rate is the hardware-independent metric.
+}
+
+// === INTERNAL HELPERS ===
+
+// argmax returns the index of the maximum value.
+func argmax(v []float64) int {
+	best := 0
+	for i := 1; i < len(v); i++ {
+		if v[i] > v[best] {
+			best = i
+		}
+	}
+	return best
+}
+
+// argsortDesc returns indices sorted by descending value.
+func argsortDesc(v []float64) []int {
+	indices := make([]int, len(v))
+	for i := range indices {
+		indices[i] = i
+	}
+	sort.Slice(indices, func(a, b int) bool {
+		return v[indices[a]] > v[indices[b]]
+	})
+	return indices
+}

--- a/research/ml/microbeam_test.go
+++ b/research/ml/microbeam_test.go
@@ -1,0 +1,496 @@
+//go:build research
+
+package ml
+
+import (
+	"math"
+	"math/rand/v2"
+	"testing"
+)
+
+// === TEST HELPERS ===
+
+// trainBeamTestModel trains a small model for beam search tests.
+// Uses a tiny corpus and few steps for speed.
+func trainBeamTestModel(t *testing.T, bc BeamConfig, steps int) (*FloatGPTParams, []rune, map[rune]int, int) {
+	t.Helper()
+	docs := []string{
+		"emma", "olivia", "ava", "sophia", "isabella",
+		"mia", "charlotte", "amelia", "harper", "evelyn",
+	}
+	chars, charToIdx, bos := BuildVocab(docs)
+	rng := rand.New(rand.NewPCG(42, 0))
+	result := TrainBeamModel(docs, chars, charToIdx, bos, bc, steps, rng, false)
+	fp := ExtractFloatParams(result.Params)
+	return fp, chars, charToIdx, bos
+}
+
+// === TRAINING TESTS ===
+
+func TestTrainBeamModelTargetLossDecreases(t *testing.T) {
+	docs := []string{"emma", "olivia", "ava", "sophia", "mia"}
+	chars, charToIdx, bos := BuildVocab(docs)
+	rng := rand.New(rand.NewPCG(42, 0))
+	result := TrainBeamModel(docs, chars, charToIdx, bos, TargetBeamConfig(), 200, rng, false)
+
+	if result.FinalLoss >= result.LossHistory[0] {
+		t.Errorf("target model loss did not decrease: initial=%.4f final=%.4f",
+			result.LossHistory[0], result.FinalLoss)
+	}
+}
+
+func TestTrainBeamModelDraftLossDecreases(t *testing.T) {
+	docs := []string{"emma", "olivia", "ava", "sophia", "mia"}
+	chars, charToIdx, bos := BuildVocab(docs)
+	rng := rand.New(rand.NewPCG(42, 0))
+	result := TrainBeamModel(docs, chars, charToIdx, bos, DraftBeamConfig(), 200, rng, false)
+
+	if result.FinalLoss >= result.LossHistory[0] {
+		t.Errorf("draft model loss did not decrease: initial=%.4f final=%.4f",
+			result.LossHistory[0], result.FinalLoss)
+	}
+}
+
+func TestTrainBeamModelDifferentSizes(t *testing.T) {
+	docs := []string{"emma", "olivia", "ava"}
+	chars, charToIdx, bos := BuildVocab(docs)
+	rng := rand.New(rand.NewPCG(42, 0))
+
+	targetResult := TrainBeamModel(docs, chars, charToIdx, bos, TargetBeamConfig(), 50, rng, false)
+	draftResult := TrainBeamModel(docs, chars, charToIdx, bos, DraftBeamConfig(), 50, rng, false)
+
+	targetParams := len(targetResult.Params.AllParams())
+	draftParams := len(draftResult.Params.AllParams())
+
+	if targetParams <= draftParams {
+		t.Errorf("target model should have more params than draft: target=%d draft=%d",
+			targetParams, draftParams)
+	}
+}
+
+// === FORWARD PASS TESTS ===
+
+func TestBeamForwardProducesLogits(t *testing.T) {
+	fp, _, _, bos := trainBeamTestModel(t, TargetBeamConfig(), 50)
+	keys := MakeBeamKV(fp.Config.NLayer)
+	values := MakeBeamKV(fp.Config.NLayer)
+
+	logits := beamForward(bos, 0, &keys, &values, fp)
+
+	if len(logits) != fp.Config.VocabSize {
+		t.Errorf("expected %d logits, got %d", fp.Config.VocabSize, len(logits))
+	}
+
+	// KV cache should have 1 entry per layer
+	for li := range keys {
+		if len(keys[li]) != 1 {
+			t.Errorf("layer %d: expected 1 key entry, got %d", li, len(keys[li]))
+		}
+	}
+}
+
+func TestFeedPromptBuildsKVCache(t *testing.T) {
+	fp, _, charToIdx, bos := trainBeamTestModel(t, TargetBeamConfig(), 50)
+	prompt := []int{bos, charToIdx['a']}
+	keys, values, logits := feedPrompt(prompt, fp)
+
+	if len(logits) != fp.Config.VocabSize {
+		t.Errorf("expected %d logits, got %d", fp.Config.VocabSize, len(logits))
+	}
+	for li := range keys {
+		if len(keys[li]) != len(prompt) {
+			t.Errorf("layer %d: expected %d key entries, got %d", li, len(prompt), len(keys[li]))
+		}
+		if len(values[li]) != len(prompt) {
+			t.Errorf("layer %d: expected %d value entries, got %d", li, len(prompt), len(values[li]))
+		}
+	}
+}
+
+// === CLONE KV TESTS ===
+
+func TestCloneBeamKVIsDeepCopy(t *testing.T) {
+	kv := MakeBeamKV(2)
+	kv[0] = append(kv[0], []float64{1.0, 2.0, 3.0})
+	kv[1] = append(kv[1], []float64{4.0, 5.0, 6.0})
+
+	cloned := CloneBeamKV(kv)
+
+	// Modify original
+	kv[0][0][0] = 999.0
+
+	// Clone should be unaffected
+	if cloned[0][0][0] != 1.0 {
+		t.Errorf("clone was affected by original mutation: got %f, want 1.0", cloned[0][0][0])
+	}
+}
+
+// === DECODING STRATEGY TESTS ===
+
+func TestDecodeGreedyDeterministic(t *testing.T) {
+	fp, _, charToIdx, bos := trainBeamTestModel(t, TargetBeamConfig(), 100)
+	prompt := []int{bos, charToIdx['a']}
+
+	r1 := DecodeGreedy(prompt, fp, 12)
+	r2 := DecodeGreedy(prompt, fp, 12)
+
+	if len(r1.Tokens) != len(r2.Tokens) {
+		t.Fatalf("greedy should be deterministic: got different lengths %d vs %d",
+			len(r1.Tokens), len(r2.Tokens))
+	}
+	for i := range r1.Tokens {
+		if r1.Tokens[i] != r2.Tokens[i] {
+			t.Errorf("greedy token %d differs: %d vs %d", i, r1.Tokens[i], r2.Tokens[i])
+		}
+	}
+	if r1.LogProb != r2.LogProb {
+		t.Errorf("greedy log-prob differs: %f vs %f", r1.LogProb, r2.LogProb)
+	}
+}
+
+func TestDecodeGreedyProducesTokens(t *testing.T) {
+	fp, _, charToIdx, bos := trainBeamTestModel(t, TargetBeamConfig(), 100)
+	prompt := []int{bos, charToIdx['a']}
+	r := DecodeGreedy(prompt, fp, 12)
+
+	if len(r.Tokens) == 0 {
+		t.Error("greedy produced no tokens")
+	}
+	if r.LogProb >= 0 {
+		t.Errorf("log-prob should be negative, got %f", r.LogProb)
+	}
+}
+
+func TestDecodeTemperatureProducesTokens(t *testing.T) {
+	fp, _, charToIdx, bos := trainBeamTestModel(t, TargetBeamConfig(), 100)
+	prompt := []int{bos, charToIdx['a']}
+	rng := rand.New(rand.NewPCG(99, 0))
+
+	r := DecodeTemperature(prompt, fp, 12, 0.8, rng)
+	if len(r.Tokens) == 0 {
+		t.Error("temperature sampling produced no tokens")
+	}
+}
+
+func TestDecodeTemperatureDiversityVsGreedy(t *testing.T) {
+	fp, _, charToIdx, bos := trainBeamTestModel(t, TargetBeamConfig(), 200)
+
+	// Generate multiple samples with temperature and greedy
+	nSamples := 10
+	greedyResults := make(map[string]bool)
+	tempResults := make(map[string]bool)
+
+	prompt := []int{bos, charToIdx['a']}
+	for i := 0; i < nSamples; i++ {
+		g := DecodeGreedy(prompt, fp, 12)
+		greedyResults[tokensToKey(g.Tokens)] = true
+
+		rng := rand.New(rand.NewPCG(uint64(i*31), 0))
+		te := DecodeTemperature(prompt, fp, 12, 1.2, rng)
+		tempResults[tokensToKey(te.Tokens)] = true
+	}
+
+	// Greedy should always produce the same output
+	if len(greedyResults) != 1 {
+		t.Errorf("greedy should produce 1 unique result, got %d", len(greedyResults))
+	}
+}
+
+func TestDecodeTopKProducesTokens(t *testing.T) {
+	fp, _, charToIdx, bos := trainBeamTestModel(t, TargetBeamConfig(), 100)
+	prompt := []int{bos, charToIdx['a']}
+	rng := rand.New(rand.NewPCG(99, 0))
+
+	r := DecodeTopK(prompt, fp, 12, 5, rng)
+	if len(r.Tokens) == 0 {
+		t.Error("top-k produced no tokens")
+	}
+}
+
+func TestDecodeTopPProducesTokens(t *testing.T) {
+	fp, _, charToIdx, bos := trainBeamTestModel(t, TargetBeamConfig(), 100)
+	prompt := []int{bos, charToIdx['a']}
+	rng := rand.New(rand.NewPCG(99, 0))
+
+	r := DecodeTopP(prompt, fp, 12, 0.9, rng)
+	if len(r.Tokens) == 0 {
+		t.Error("top-p produced no tokens")
+	}
+}
+
+func TestDecodeBeamDeterministic(t *testing.T) {
+	fp, _, charToIdx, bos := trainBeamTestModel(t, TargetBeamConfig(), 100)
+	prompt := []int{bos, charToIdx['a']}
+
+	r1 := DecodeBeam(prompt, fp, 12, 3)
+	r2 := DecodeBeam(prompt, fp, 12, 3)
+
+	if len(r1.Tokens) != len(r2.Tokens) {
+		t.Fatalf("beam should be deterministic: got different lengths %d vs %d",
+			len(r1.Tokens), len(r2.Tokens))
+	}
+	for i := range r1.Tokens {
+		if r1.Tokens[i] != r2.Tokens[i] {
+			t.Errorf("beam token %d differs: %d vs %d", i, r1.Tokens[i], r2.Tokens[i])
+		}
+	}
+}
+
+func TestDecodeBeamAtLeastAsGoodAsGreedy(t *testing.T) {
+	fp, _, charToIdx, bos := trainBeamTestModel(t, TargetBeamConfig(), 200)
+	prompt := []int{bos, charToIdx['a']}
+
+	greedy := DecodeGreedy(prompt, fp, 12)
+	beam := DecodeBeam(prompt, fp, 12, 3)
+
+	// Beam search explores multiple paths, should find equal or better log-prob
+	if beam.LogProb < greedy.LogProb-0.1 {
+		t.Errorf("beam search (%.4f) significantly worse than greedy (%.4f)",
+			beam.LogProb, greedy.LogProb)
+	}
+}
+
+func TestDecodeBeamWidthEffect(t *testing.T) {
+	fp, _, charToIdx, bos := trainBeamTestModel(t, TargetBeamConfig(), 200)
+	prompt := []int{bos, charToIdx['a']}
+
+	// Width 1 = greedy (in terms of search behavior)
+	beam1 := DecodeBeam(prompt, fp, 12, 1)
+	beam5 := DecodeBeam(prompt, fp, 12, 5)
+
+	// Wider beam should find equal or better log-prob
+	if beam5.LogProb < beam1.LogProb-0.1 {
+		t.Errorf("wider beam (%.4f) significantly worse than beam-1 (%.4f)",
+			beam5.LogProb, beam1.LogProb)
+	}
+}
+
+func TestDecodeSpeculativeProducesTokens(t *testing.T) {
+	targetFP, chars, charToIdx, bos := trainBeamTestModel(t, TargetBeamConfig(), 100)
+
+	// Train draft model
+	docs := []string{"emma", "olivia", "ava", "sophia", "isabella",
+		"mia", "charlotte", "amelia", "harper", "evelyn"}
+	rng := rand.New(rand.NewPCG(99, 0))
+	draftResult := TrainBeamModel(docs, chars, charToIdx, bos, DraftBeamConfig(), 100, rng, false)
+	draftFP := ExtractFloatParams(draftResult.Params)
+
+	prompt := []int{bos, charToIdx['a']}
+	r := DecodeSpeculative(prompt, targetFP, draftFP, 12, 4, rng)
+
+	if len(r.Tokens) == 0 {
+		t.Error("speculative decoding produced no tokens")
+	}
+}
+
+func TestDecodeSpeculativeAcceptanceTracking(t *testing.T) {
+	targetFP, chars, charToIdx, bos := trainBeamTestModel(t, TargetBeamConfig(), 100)
+
+	docs := []string{"emma", "olivia", "ava", "sophia", "isabella",
+		"mia", "charlotte", "amelia", "harper", "evelyn"}
+	rng := rand.New(rand.NewPCG(99, 0))
+	draftResult := TrainBeamModel(docs, chars, charToIdx, bos, DraftBeamConfig(), 100, rng, false)
+	draftFP := ExtractFloatParams(draftResult.Params)
+
+	prompt := []int{bos, charToIdx['a']}
+	r := DecodeSpeculative(prompt, targetFP, draftFP, 12, 4, rng)
+
+	// Accepted should not exceed proposed
+	if r.Accepted > r.Proposed {
+		t.Errorf("accepted (%d) exceeds proposed (%d)", r.Accepted, r.Proposed)
+	}
+	// Should have generated at least as many tokens as accepted
+	if len(r.Tokens) < r.Accepted {
+		t.Errorf("fewer tokens (%d) than accepted (%d)", len(r.Tokens), r.Accepted)
+	}
+}
+
+// === LOG-PROB VALIDITY TESTS ===
+
+func TestAllStrategiesNegativeLogProb(t *testing.T) {
+	fp, chars, charToIdx, bos := trainBeamTestModel(t, TargetBeamConfig(), 100)
+	prompt := []int{bos, charToIdx['a']}
+	rng := rand.New(rand.NewPCG(42, 0))
+
+	strategies := []struct {
+		name string
+		fn   func() DecodeResult
+	}{
+		{"Greedy", func() DecodeResult { return DecodeGreedy(prompt, fp, 12) }},
+		{"Temperature", func() DecodeResult { return DecodeTemperature(prompt, fp, 12, 0.8, rng) }},
+		{"Top-K", func() DecodeResult { return DecodeTopK(prompt, fp, 12, 5, rng) }},
+		{"Top-P", func() DecodeResult { return DecodeTopP(prompt, fp, 12, 0.9, rng) }},
+		{"Beam", func() DecodeResult { return DecodeBeam(prompt, fp, 12, 3) }},
+	}
+
+	for _, s := range strategies {
+		r := s.fn()
+		if len(r.Tokens) > 0 && r.LogProb >= 0 {
+			t.Errorf("%s: log-prob should be negative for non-empty output, got %f", s.name, r.LogProb)
+		}
+	}
+
+	// Speculative
+	docs := []string{"emma", "olivia", "ava", "sophia", "isabella",
+		"mia", "charlotte", "amelia", "harper", "evelyn"}
+	draftResult := TrainBeamModel(docs, chars, charToIdx, bos, DraftBeamConfig(), 100, rng, false)
+	draftFP := ExtractFloatParams(draftResult.Params)
+	sr := DecodeSpeculative(prompt, fp, draftFP, 12, 4, rng)
+	if len(sr.Tokens) > 0 && sr.LogProb >= 0 {
+		t.Errorf("Speculative: log-prob should be negative, got %f", sr.LogProb)
+	}
+}
+
+// === MAX LENGTH CONSTRAINT TESTS ===
+
+func TestDecodeGreedyMaxLen(t *testing.T) {
+	fp, _, charToIdx, bos := trainBeamTestModel(t, TargetBeamConfig(), 100)
+	prompt := []int{bos, charToIdx['a']}
+
+	r := DecodeGreedy(prompt, fp, 3)
+	if len(r.Tokens) > 3 {
+		t.Errorf("greedy exceeded maxLen=3: got %d tokens", len(r.Tokens))
+	}
+}
+
+func TestDecodeBeamMaxLen(t *testing.T) {
+	fp, _, charToIdx, bos := trainBeamTestModel(t, TargetBeamConfig(), 100)
+	prompt := []int{bos, charToIdx['a']}
+
+	r := DecodeBeam(prompt, fp, 3, 3)
+	if len(r.Tokens) > 3 {
+		t.Errorf("beam exceeded maxLen=3: got %d tokens", len(r.Tokens))
+	}
+}
+
+// === ARGMAX / ARGSORT TESTS ===
+
+func TestArgmax(t *testing.T) {
+	tests := []struct {
+		input    []float64
+		expected int
+	}{
+		{[]float64{1, 3, 2}, 1},
+		{[]float64{5, 1, 2}, 0},
+		{[]float64{1, 2, 5}, 2},
+		{[]float64{1}, 0},
+	}
+	for _, tt := range tests {
+		got := argmax(tt.input)
+		if got != tt.expected {
+			t.Errorf("argmax(%v) = %d, want %d", tt.input, got, tt.expected)
+		}
+	}
+}
+
+func TestArgsortDesc(t *testing.T) {
+	input := []float64{0.1, 0.5, 0.3, 0.8, 0.2}
+	sorted := argsortDesc(input)
+
+	// Should be sorted by descending value
+	for i := 1; i < len(sorted); i++ {
+		if input[sorted[i]] > input[sorted[i-1]] {
+			t.Errorf("argsortDesc not sorted at position %d: value %f > %f",
+				i, input[sorted[i]], input[sorted[i-1]])
+		}
+	}
+	// First should be index 3 (0.8)
+	if sorted[0] != 3 {
+		t.Errorf("expected index 3 first, got %d", sorted[0])
+	}
+}
+
+// === BEAM CONFIG TESTS ===
+
+func TestBeamConfigToGPTConfig(t *testing.T) {
+	bc := TargetBeamConfig()
+	cfg := bc.ToGPTConfig(27)
+
+	if cfg.NEmbd != beamTargetNEmbd {
+		t.Errorf("NEmbd = %d, want %d", cfg.NEmbd, beamTargetNEmbd)
+	}
+	if cfg.NHead != beamTargetNHead {
+		t.Errorf("NHead = %d, want %d", cfg.NHead, beamTargetNHead)
+	}
+	if cfg.BlockSize != beamBlockSize {
+		t.Errorf("BlockSize = %d, want %d", cfg.BlockSize, beamBlockSize)
+	}
+	if cfg.VocabSize != 27 {
+		t.Errorf("VocabSize = %d, want 27", cfg.VocabSize)
+	}
+}
+
+func TestDraftBeamConfigSmaller(t *testing.T) {
+	target := TargetBeamConfig()
+	draft := DraftBeamConfig()
+
+	if draft.NEmbd >= target.NEmbd {
+		t.Errorf("draft NEmbd (%d) should be smaller than target (%d)", draft.NEmbd, target.NEmbd)
+	}
+	if draft.NHead >= target.NHead {
+		t.Errorf("draft NHead (%d) should be smaller than target (%d)", draft.NHead, target.NHead)
+	}
+}
+
+// === BENCHMARKS ===
+
+func BenchmarkDecodeGreedy(b *testing.B) {
+	docs := []string{"emma", "olivia", "ava", "sophia", "isabella",
+		"mia", "charlotte", "amelia", "harper", "evelyn"}
+	chars, charToIdx, bos := BuildVocab(docs)
+	rng := rand.New(rand.NewPCG(42, 0))
+	result := TrainBeamModel(docs, chars, charToIdx, bos, TargetBeamConfig(), 50, rng, false)
+	fp := ExtractFloatParams(result.Params)
+	prompt := []int{bos, charToIdx['a']}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		DecodeGreedy(prompt, fp, 12)
+	}
+}
+
+func BenchmarkDecodeBeam(b *testing.B) {
+	docs := []string{"emma", "olivia", "ava", "sophia", "isabella",
+		"mia", "charlotte", "amelia", "harper", "evelyn"}
+	chars, charToIdx, bos := BuildVocab(docs)
+	rng := rand.New(rand.NewPCG(42, 0))
+	result := TrainBeamModel(docs, chars, charToIdx, bos, TargetBeamConfig(), 50, rng, false)
+	fp := ExtractFloatParams(result.Params)
+	prompt := []int{bos, charToIdx['a']}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		DecodeBeam(prompt, fp, 12, 3)
+	}
+}
+
+func BenchmarkDecodeSpeculative(b *testing.B) {
+	docs := []string{"emma", "olivia", "ava", "sophia", "isabella",
+		"mia", "charlotte", "amelia", "harper", "evelyn"}
+	chars, charToIdx, bos := BuildVocab(docs)
+	rng := rand.New(rand.NewPCG(42, 0))
+	targetResult := TrainBeamModel(docs, chars, charToIdx, bos, TargetBeamConfig(), 50, rng, false)
+	draftResult := TrainBeamModel(docs, chars, charToIdx, bos, DraftBeamConfig(), 50, rng, false)
+	targetFP := ExtractFloatParams(targetResult.Params)
+	draftFP := ExtractFloatParams(draftResult.Params)
+	prompt := []int{bos, charToIdx['a']}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		rng2 := rand.New(rand.NewPCG(uint64(i), 0))
+		DecodeSpeculative(prompt, targetFP, draftFP, 12, 4, rng2)
+	}
+}
+
+// === HELPER ===
+
+func tokensToKey(tokens []int) string {
+	key := make([]byte, len(tokens))
+	for i, t := range tokens {
+		key[i] = byte(t)
+	}
+	return string(key)
+}
+
+// Silence unused import
+var _ = math.Abs


### PR DESCRIPTION
## Summary
- Port of `microbeam.py` from no-magic: 6 decoding strategies for language model text generation
- Greedy, temperature, top-k, top-p (nucleus), beam search, and speculative decoding with draft-verify pipeline
- Dual-model training: target (16-dim, 4-head) and draft (8-dim, 2-head) models for speculative decoding
- Reuses existing autograd (`value.go`), GPT architecture (`microgpt.go`), and float inference (`microquant.go`)
- 24 tests + 3 benchmarks, `//go:build research` tagged, zero dependencies