### PR TITLE
Bump Rust Docker image to 1.88 for time crate compat

### DIFF
--- a/services/rust-grpc/Dockerfile
+++ b/services/rust-grpc/Dockerfile
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
 # Build stage
-FROM rust:1.85-slim-bookworm AS builder
+FROM rust:1.88-slim-bookworm AS builder
 
 RUN apt-get update && apt-get install -y protobuf-compiler && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Summary
- Bumps `rust:1.85-slim-bookworm` → `rust:1.88-slim-bookworm` in `services/rust-grpc/Dockerfile`
- The `time@0.3.47` crate requires `rustc 1.88.0+`, which caused the previous Cloud Run deploy to fail during Docker build
- No code changes — Dockerfile base image version only