### PR TITLE
Fix Dockerfile cargo cache: dummy binary wasn't rebuilt with real source

### DIFF
--- a/services/rust-grpc/Dockerfile
+++ b/services/rust-grpc/Dockerfile
@@ -13,11 +13,11 @@ COPY proto/ proto/
 COPY build.rs ./
 RUN mkdir src && echo 'fn main() {}' > src/main.rs
 RUN cargo build --release 2>/dev/null || true
-RUN rm -rf src
+RUN rm -rf src target/release/hermit-server target/release/deps/hermit*
 
 # Build real binary
 COPY src/ src/
-RUN cargo build --release
+RUN touch src/main.rs && cargo build --release
 
 # Runtime stage
 FROM debian:bookworm-slim


### PR DESCRIPTION
## Summary
- The dependency-caching pattern (build with dummy `fn main() {}`, then copy real source) left the compiled binary in `target/release/`, so cargo's second `cargo build --release` was a no-op
- The deployed container was literally `fn main() {}` — started and immediately exited with code 0
- Fix: delete the dummy binary and its deps before the real build, and `touch src/main.rs` to force mtime invalidation
- Verified locally: container now starts, logs startup messages, and listens on port 8080