### PR TITLE
feat: add env var and CLI flag overrides for TUI backend addresses

### DIFF
--- a/cmd/tui/internal/app/hermitclient.go
+++ b/cmd/tui/internal/app/hermitclient.go
@@ -42,17 +42,24 @@ type grpcHermitClient struct {
 }
 
 // NewHermitClient dials addr and returns a HermitClient.
-// Uses TLS with InsecureSkipVerify (self-signed accepted; identity validated by secret).
-// Falls back to insecure transport if TLS dial fails (dev/local mode).
+//
+// TLS modes:
+//   - insecurePlaintext=true:  plaintext h2c (local Docker, dev mode)
+//   - insecurePlaintext=false: proper TLS with system CA pool (Cloud Run, production)
+//
 // Non-blocking: errors surface on first RPC call.
-func NewHermitClient(addr, secret string) (HermitClient, error) {
-	tlsCreds := credentials.NewTLS(&tls.Config{InsecureSkipVerify: true}) //nolint:gosec
-	conn, err := grpc.NewClient(addr, grpc.WithTransportCredentials(tlsCreds))
+func NewHermitClient(addr, secret string, insecurePlaintext bool) (HermitClient, error) {
+	var creds credentials.TransportCredentials
+	if insecurePlaintext {
+		creds = insecure.NewCredentials()
+	} else {
+		// Production: use system CA pool. Cloud Run has valid certs from Google.
+		creds = credentials.NewTLS(&tls.Config{MinVersion: tls.VersionTLS12})
+	}
+
+	conn, err := grpc.NewClient(addr, grpc.WithTransportCredentials(creds))
 	if err != nil {
-		conn, err = grpc.NewClient(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
-		if err != nil {
-			return nil, fmt.Errorf("connect to %s: %w", addr, err)
-		}
+		return nil, fmt.Errorf("connect to %s: %w", addr, err)
 	}
 	return &grpcHermitClient{
 		conn:   conn,

--- a/cmd/tui/main.go
+++ b/cmd/tui/main.go
@@ -4,6 +4,7 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"os"
 
@@ -26,9 +27,10 @@ import (
 // obfKey is re-encoded with the binary name so a renamed binary decodes to
 // garbage (mild tamper signal).
 //
-// Dev mode: leave all three empty; falls back to localhost:9090, no secret.
+// Dev mode: leave all three empty; falls back to defaults (overridable via
+// env vars or CLI flags).
 //
-// Secrets service URL is always baked via SECRETS_URL ldflag in production.
+// Resolution priority: CLI flag > env var > obf build-time > hardcoded default.
 var (
 	obfAddr       string
 	obfSecret     string
@@ -36,65 +38,127 @@ var (
 	obfSecretsURL string
 )
 
-func resolveConfig() (addr, secret, secretsURL string, devMode bool) {
-	if obfAddr == "" || obfSecret == "" || obfKey == "" {
-		return "localhost:9090", "", "http://localhost:8080", true
+// config holds the resolved TUI configuration after merging all sources.
+type config struct {
+	HermitAddr string // gRPC address for hermit server
+	Secret     string // x-hermit-secret value
+	SecretsURL string // HTTP base URL for secrets service
+	Insecure   bool   // true = plaintext gRPC (no TLS)
+	DevMode    bool   // true = no build-time config baked in
+}
+
+// resolveConfig merges build-time, env var, and CLI flag sources.
+// Priority: CLI flag > env var > obf build-time > hardcoded default.
+func resolveConfig() config {
+	// --- CLI flags ---
+	flagAddr := flag.String("hermit-addr", "", "hermit gRPC address (host:port)")
+	flagSecret := flag.String("hermit-secret", "", "x-hermit-secret shared secret")
+	flagSecretsURL := flag.String("secrets-url", "", "secrets HTTP base URL")
+	flagInsecure := flag.Bool("insecure", false, "use plaintext gRPC (no TLS)")
+	flag.Parse()
+
+	// --- Start with hardcoded defaults ---
+	cfg := config{
+		HermitAddr: "localhost:9090",
+		Secret:     "",
+		SecretsURL: "http://localhost:8081",
+		Insecure:   true, // dev default: local Docker runs plaintext h2c
+		DevMode:    true,
 	}
 
-	// The binary name is the seed for decoding obfKey.
-	// Renaming the binary intentionally breaks decoding.
-	binaryName := "tui"
-	if len(os.Args) > 0 {
-		binaryName = os.Args[0]
-	}
+	// --- Layer: obf build-time values (if baked in) ---
+	if obfAddr != "" && obfSecret != "" && obfKey != "" {
+		binaryName := "tui"
+		if len(os.Args) > 0 {
+			binaryName = os.Args[0]
+		}
 
-	passphrase, err := obf.Decode(obfKey, binaryName)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "tui: key decode failed: %v\n", err)
-		os.Exit(1)
-	}
-
-	resolvedAddr, err := obf.Decode(obfAddr, passphrase)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "tui: addr decode failed: %v\n", err)
-		os.Exit(1)
-	}
-
-	resolvedSecret, err := obf.Decode(obfSecret, passphrase)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "tui: secret decode failed: %v\n", err)
-		os.Exit(1)
-	}
-
-	resolvedSecretsURL := "http://localhost:8080"
-	if obfSecretsURL != "" {
-		u, err := obf.Decode(obfSecretsURL, passphrase)
+		passphrase, err := obf.Decode(obfKey, binaryName)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "tui: secrets URL decode failed: %v\n", err)
+			fmt.Fprintf(os.Stderr, "tui: key decode failed: %v\n", err)
 			os.Exit(1)
 		}
-		resolvedSecretsURL = u
+
+		resolvedAddr, err := obf.Decode(obfAddr, passphrase)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "tui: addr decode failed: %v\n", err)
+			os.Exit(1)
+		}
+
+		resolvedSecret, err := obf.Decode(obfSecret, passphrase)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "tui: secret decode failed: %v\n", err)
+			os.Exit(1)
+		}
+
+		cfg.HermitAddr = resolvedAddr
+		cfg.Secret = resolvedSecret
+		cfg.Insecure = false // production builds use TLS
+		cfg.DevMode = false
+
+		if obfSecretsURL != "" {
+			u, err := obf.Decode(obfSecretsURL, passphrase)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "tui: secrets URL decode failed: %v\n", err)
+				os.Exit(1)
+			}
+			cfg.SecretsURL = u
+		}
 	}
 
-	return resolvedAddr, resolvedSecret, resolvedSecretsURL, false
+	// --- Layer: env vars override build-time ---
+	if v := os.Getenv("HERMIT_ADDR"); v != "" {
+		cfg.HermitAddr = v
+	}
+	if v := os.Getenv("HERMIT_SECRET"); v != "" {
+		cfg.Secret = v
+	}
+	if v := os.Getenv("SECRETS_URL"); v != "" {
+		cfg.SecretsURL = v
+	}
+	if v := os.Getenv("HERMIT_INSECURE"); v == "1" || v == "true" {
+		cfg.Insecure = true
+	} else if v == "0" || v == "false" {
+		cfg.Insecure = false
+	}
+
+	// --- Layer: CLI flags override everything ---
+	if *flagAddr != "" {
+		cfg.HermitAddr = *flagAddr
+	}
+	if *flagSecret != "" {
+		cfg.Secret = *flagSecret
+	}
+	if *flagSecretsURL != "" {
+		cfg.SecretsURL = *flagSecretsURL
+	}
+	// flag.Bool has no "was set" check, so we only override if the flag was
+	// explicitly passed. We use flag.Visit to detect this.
+	flag.Visit(func(f *flag.Flag) {
+		if f.Name == "insecure" {
+			cfg.Insecure = *flagInsecure
+		}
+	})
+
+	return cfg
 }
 
 func main() {
-	addr, secret, secretsURL, devMode := resolveConfig()
+	cfg := resolveConfig()
 
-	if devMode {
+	if cfg.DevMode {
 		fmt.Fprintln(os.Stderr, "tui: dev mode (no build-time config baked in)")
 	}
 
-	hermitClient, err := app.NewHermitClient(addr, secret)
+	hermitClient, err := app.NewHermitClient(cfg.HermitAddr, cfg.Secret, cfg.Insecure)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "tui: hermit dial: %v\n", err)
 		os.Exit(1)
 	}
 
-	secretsClient := app.NewSecretsClient(secretsURL)
+	secretsClient := app.NewSecretsClient(cfg.SecretsURL)
 
-	m := app.New(addr, secret, hermitClient, secretsClient)
+	m := app.New(cfg.HermitAddr, cfg.Secret, hermitClient, secretsClient)
 	p := tea.NewProgram(m)
 	if _, err := p.Run(); err != nil {
 		fmt.Fprintf(os.Stderr, "tui: %v\n", err)


### PR DESCRIPTION
## Summary
- TUI backend addresses now configurable via CLI flags + env vars, not just build-time obfuscation
- Priority: CLI flag > env var > obf build-time > hardcoded default
- Dev defaults match local Docker stack: `localhost:9090` (hermit), `http://localhost:8081` (secrets), `--insecure` (plaintext h2c)
- Fixes `InsecureSkipVerify` — production now uses system CA pool (Cloud Run has valid Google certs)
- Usage: `tui --hermit-addr localhost:9090 --insecure` or `HERMIT_ADDR=localhost:9090 tui`

| Flag | Env Var | Default (dev) |
|------|---------|---------------|
| `--hermit-addr` | `HERMIT_ADDR` | `localhost:9090` |
| `--hermit-secret` | `HERMIT_SECRET` | (empty) |
| `--secrets-url` | `SECRETS_URL` | `http://localhost:8081` |
| `--insecure` | `HERMIT_INSECURE` | `true` (dev), `false` (prod) |