### PR TITLE
feat: bake obfuscated Cloud Run URLs into TUI build

### DIFF
--- a/.gitea/workflows/install.yml
+++ b/.gitea/workflows/install.yml
@@ -15,13 +15,27 @@ jobs:
           fetch-depth: 2
 
       - name: Detect changes and install
+        env:
+          OBF_PASSPHRASE: ${{ secrets.OBF_PASSPHRASE }}
+          HERMIT_ADDR_PLAIN: ${{ secrets.HERMIT_ADDR_PLAIN }}
+          HERMIT_SECRET_PLAIN: ${{ secrets.HERMIT_SECRET_PLAIN }}
+          SECRETS_URL_PLAIN: ${{ secrets.SECRETS_URL_PLAIN }}
         run: |
           CHANGED=$(git diff --name-only HEAD~1 HEAD)
 
-          # tui — Go TUI client
+          # tui — Go TUI client (with obfuscated prod values if secrets are set)
           if echo "$CHANGED" | grep -qE '^(cmd/tui/|go\.(mod|sum)$)'; then
-            echo "==> Installing tui"
-            go install ./cmd/tui
+            if [ -n "$OBF_PASSPHRASE" ] && [ -n "$HERMIT_ADDR_PLAIN" ] && [ -n "$HERMIT_SECRET_PLAIN" ]; then
+              echo "==> Installing tui (prod build with obf values)"
+              make install-prod \
+                PASSPHRASE="$OBF_PASSPHRASE" \
+                HERMIT_ADDR_PLAIN="$HERMIT_ADDR_PLAIN" \
+                HERMIT_SECRET_PLAIN="$HERMIT_SECRET_PLAIN" \
+                SECRETS_URL_PLAIN="$SECRETS_URL_PLAIN"
+            else
+              echo "==> Installing tui (dev build, no obf secrets)"
+              go install ./cmd/tui
+            fi
           else
             echo "--- tui: no changes"
           fi

--- a/Makefile
+++ b/Makefile
@@ -16,16 +16,38 @@ LDFLAGS := -X main.obfKey=$(OBF_KEY) \
            -X main.obfSecret=$(OBF_SECRET) \
            -X main.obfSecretsURL=$(OBF_SECRETS_URL)
 
-.PHONY: build install test clean encode
+# Production build values (set in CI via secrets; leave empty for dev mode).
+# Used by install-prod to encode + build in one step.
+PASSPHRASE       ?=
+HERMIT_ADDR_PLAIN    ?=
+HERMIT_SECRET_PLAIN  ?=
+SECRETS_URL_PLAIN    ?=
+
+ENCODE_CMD := go run ./cmd/tui/internal/obf/encode
+
+.PHONY: build install install-prod test clean encode
 
 ## build: compile tui binary to ./bin/tui
 build:
 	@mkdir -p bin
 	go build -ldflags "$(LDFLAGS)" -o bin/$(BINARY) $(CMD_DIR)
 
-## install: install tui to GOPATH/bin
+## install: install tui to GOPATH/bin (pass pre-encoded OBF_* vars, or leave empty for dev)
 install:
 	go install -ldflags "$(LDFLAGS)" $(CMD_DIR)
+
+## install-prod: encode plaintext values and install with baked obfuscation.
+##   Requires: PASSPHRASE, HERMIT_ADDR_PLAIN, HERMIT_SECRET_PLAIN, SECRETS_URL_PLAIN
+##   Usage: make install-prod PASSPHRASE=... HERMIT_ADDR_PLAIN=... HERMIT_SECRET_PLAIN=... SECRETS_URL_PLAIN=...
+install-prod:
+	@test -n "$(PASSPHRASE)" || (echo "error: PASSPHRASE is required" && exit 1)
+	@test -n "$(HERMIT_ADDR_PLAIN)" || (echo "error: HERMIT_ADDR_PLAIN is required" && exit 1)
+	@test -n "$(HERMIT_SECRET_PLAIN)" || (echo "error: HERMIT_SECRET_PLAIN is required" && exit 1)
+	$(eval OBF_KEY := $(shell $(ENCODE_CMD) "$(PASSPHRASE)" "tui"))
+	$(eval OBF_ADDR := $(shell $(ENCODE_CMD) "$(HERMIT_ADDR_PLAIN)" "$(PASSPHRASE)"))
+	$(eval OBF_SECRET := $(shell $(ENCODE_CMD) "$(HERMIT_SECRET_PLAIN)" "$(PASSPHRASE)"))
+	$(eval OBF_SECRETS_URL := $(shell $(ENCODE_CMD) "$(SECRETS_URL_PLAIN)" "$(PASSPHRASE)"))
+	go install -ldflags "-X main.obfKey=$(OBF_KEY) -X main.obfAddr=$(OBF_ADDR) -X main.obfSecret=$(OBF_SECRET) -X main.obfSecretsURL=$(OBF_SECRETS_URL)" $(CMD_DIR)
 
 ## test: run all tests
 test:
@@ -34,7 +56,7 @@ test:
 ## encode: encode a value for ldflags embedding
 ##   Usage: make encode PLAIN=<value> PASS=<passphrase>
 encode:
-	go run ./cmd/tui/internal/obf/encode $(PLAIN) $(PASS)
+	$(ENCODE_CMD) $(PLAIN) $(PASS)
 
 ## clean: remove build artifacts
 clean:

--- a/cmd/tui/internal/obf/obf_test.go
+++ b/cmd/tui/internal/obf/obf_test.go
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 Jared Redh. All rights reserved.
+
+package obf
+
+import (
+	"testing"
+)
+
+func TestRoundTrip(t *testing.T) {
+	tests := []struct {
+		name       string
+		plaintext  string
+		passphrase string
+	}{
+		{"simple", "hello", "secret"},
+		{"url", "nexus-hermit-dev-2tvic4xjjq-uc.a.run.app:443", "my-passphrase"},
+		{"base64 secret", "jIK4zs9kee6Ezpgy5Jo/c+CR/xtNMLskrvi6Bzu2VDM=", "build-passphrase"},
+		{"https url", "https://nexus-secrets-dev-2tvic4xjjq-uc.a.run.app", "p@ss"},
+		{"empty passphrase", "some-value", ""},
+		{"unicode", "héllo wörld", "clé"},
+		{"long value", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "key"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			encoded := Encode(tt.plaintext, tt.passphrase)
+			if encoded == "" {
+				t.Fatal("Encode returned empty string")
+			}
+			if encoded == tt.plaintext {
+				t.Fatal("Encode returned plaintext unchanged")
+			}
+
+			decoded, err := Decode(encoded, tt.passphrase)
+			if err != nil {
+				t.Fatalf("Decode error: %v", err)
+			}
+			if decoded != tt.plaintext {
+				t.Fatalf("round-trip failed: got %q, want %q", decoded, tt.plaintext)
+			}
+		})
+	}
+}
+
+func TestDecode_EmptyValue(t *testing.T) {
+	_, err := Decode("", "passphrase")
+	if err == nil {
+		t.Fatal("expected error for empty encoded value")
+	}
+}
+
+func TestDecode_InvalidHex(t *testing.T) {
+	_, err := Decode("not-hex!", "passphrase")
+	if err == nil {
+		t.Fatal("expected error for invalid hex")
+	}
+}
+
+func TestDecode_WrongPassphrase(t *testing.T) {
+	encoded := Encode("secret-value", "correct-passphrase")
+	decoded, err := Decode(encoded, "wrong-passphrase")
+	if err != nil {
+		t.Fatalf("Decode should not error with wrong passphrase: %v", err)
+	}
+	if decoded == "secret-value" {
+		t.Fatal("wrong passphrase should not decode to original plaintext")
+	}
+}
+
+func TestKeyTamperDetection(t *testing.T) {
+	// obfKey is Encode(passphrase, binaryName). If the binary is renamed,
+	// Decode(obfKey, newName) returns a different passphrase, and subsequent
+	// decodes produce garbage.
+	passphrase := "build-time-secret"
+	obfKey := Encode(passphrase, "tui")
+
+	// Correct binary name recovers passphrase
+	recovered, err := Decode(obfKey, "tui")
+	if err != nil {
+		t.Fatalf("Decode error: %v", err)
+	}
+	if recovered != passphrase {
+		t.Fatalf("got %q, want %q", recovered, passphrase)
+	}
+
+	// Renamed binary gets wrong passphrase
+	wrong, err := Decode(obfKey, "renamed-binary")
+	if err != nil {
+		t.Fatalf("Decode error: %v", err)
+	}
+	if wrong == passphrase {
+		t.Fatal("renamed binary should not recover correct passphrase")
+	}
+}


### PR DESCRIPTION
## Summary

- Add `make install-prod` target that encodes plaintext values (hermit addr, secret, secrets URL) with a passphrase and builds the TUI binary with baked obfuscated values in one step
- Wire Gitea `install.yml` to use `install-prod` when `OBF_PASSPHRASE` secret is set (falls back to plain `go install` for dev)
- Add obf package unit tests: round-trip encode/decode, error handling, binary rename tamper detection
- Gitea repo secrets configured: `OBF_PASSPHRASE`, `HERMIT_ADDR_PLAIN`, `HERMIT_SECRET_PLAIN`, `SECRETS_URL_PLAIN`

## Testing

- `make install-prod` verified locally: binary starts without "dev mode" message
- `make install` (no vars): binary correctly shows "dev mode"
- All 11 obf tests pass