### PR TITLE
ci: add integration test workflow for Cloud Run dev

### DIFF
--- a/.github/workflows/integration-tests-dev.yml
+++ b/.github/workflows/integration-tests-dev.yml
@@ -1,0 +1,106 @@
+name: Integration Tests (DEV)
+
+# Run integration tests against deployed Cloud Run dev services.
+# Triggers:
+#   - After hermit or secrets deploy completes
+#   - Manual dispatch for ad-hoc verification
+
+on:
+  workflow_run:
+    workflows:
+      - "Deploy Hermit to Cloud Run (DEV)"
+      - "Deploy go-http to Cloud Run (DEV)"
+    types:
+      - completed
+    branches:
+      - main
+  workflow_dispatch:
+
+env:
+  GCP_PROJECT_ID: dea-noctua
+  GCP_REGION: us-central1
+
+jobs:
+  integration-tests:
+    name: Run Integration Tests
+    runs-on: ubuntu-latest
+    # Only run if the triggering workflow succeeded (or manual dispatch)
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24'
+          cache: true
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.WIF_PROVIDER }}
+          service_account: ${{ secrets.WIF_SERVICE_ACCOUNT }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Get service URLs and IAM token
+        id: services
+        run: |
+          # Get hermit gRPC URL (strip https:// prefix, add :443 for gRPC)
+          HERMIT_URL=$(gcloud run services describe nexus-hermit-dev \
+            --region ${{ env.GCP_REGION }} \
+            --format 'value(status.url)')
+          HERMIT_HOST=$(echo "$HERMIT_URL" | sed 's|https://||')
+          echo "hermit_addr=${HERMIT_HOST}:443" >> $GITHUB_OUTPUT
+
+          # Get secrets HTTP URL
+          SECRETS_URL=$(gcloud run services describe nexus-secrets-dev \
+            --region ${{ env.GCP_REGION }} \
+            --format 'value(status.url)')
+          echo "secrets_url=${SECRETS_URL}" >> $GITHUB_OUTPUT
+
+          # Get IAM identity token for Cloud Run auth
+          TOKEN=$(gcloud auth print-identity-token \
+            --audiences="$HERMIT_URL" \
+            --impersonate-service-account=${{ secrets.WIF_SERVICE_ACCOUNT }})
+          echo "::add-mask::$TOKEN"
+          echo "bearer_token=$TOKEN" >> $GITHUB_OUTPUT
+
+      - name: Get hermit secret from Secret Manager
+        id: hermit-secret
+        run: |
+          SECRET=$(gcloud secrets versions access latest \
+            --secret=hermit-secret-dev \
+            --project=${{ env.GCP_PROJECT_ID }})
+          echo "::add-mask::$SECRET"
+          echo "value=$SECRET" >> $GITHUB_OUTPUT
+
+      - name: Run integration tests
+        env:
+          HERMIT_ADDR: ${{ steps.services.outputs.hermit_addr }}
+          HERMIT_SECRET: ${{ steps.hermit-secret.outputs.value }}
+          HERMIT_BEARER_TOKEN: ${{ steps.services.outputs.bearer_token }}
+          SECRETS_URL: ${{ steps.services.outputs.secrets_url }}
+        run: |
+          echo "Testing hermit at: $HERMIT_ADDR"
+          echo "Testing secrets at: $SECRETS_URL"
+          go test -tags integration -v -count=1 -timeout 60s ./tests/integration/...
+
+      - name: Summary
+        if: always()
+        run: |
+          echo "## Integration Test Results" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- **Hermit**: nexus-hermit-dev" >> $GITHUB_STEP_SUMMARY
+          echo "- **Secrets**: nexus-secrets-dev" >> $GITHUB_STEP_SUMMARY
+          echo "- **Trigger**: ${{ github.event_name }}" >> $GITHUB_STEP_SUMMARY
+          if [ "${{ github.event_name }}" = "workflow_run" ]; then
+            echo "- **Source workflow**: ${{ github.event.workflow_run.name }}" >> $GITHUB_STEP_SUMMARY
+            echo "- **Source conclusion**: ${{ github.event.workflow_run.conclusion }}" >> $GITHUB_STEP_SUMMARY
+          fi

--- a/tests/integration/doc.go
+++ b/tests/integration/doc.go
@@ -7,8 +7,9 @@
 //
 // Environment variables:
 //
-//	HERMIT_ADDR      gRPC address (default: localhost:9090)
-//	HERMIT_SECRET    shared secret for x-hermit-secret header (optional)
-//	HERMIT_INSECURE  set to "true" to disable TLS (default: TLS with InsecureSkipVerify)
-//	SECRETS_URL      HTTP base URL (default: http://localhost:8082)
+//	HERMIT_ADDR         gRPC address (default: localhost:9090)
+//	HERMIT_SECRET       shared secret for x-hermit-secret header (optional)
+//	HERMIT_INSECURE     set to "true" to disable TLS (default: TLS with system CAs)
+//	HERMIT_BEARER_TOKEN OAuth2/IAM bearer token for Cloud Run auth (optional)
+//	SECRETS_URL         HTTP base URL (default: http://localhost:8082)
 package integration

--- a/tests/integration/hermit_test.go
+++ b/tests/integration/hermit_test.go
@@ -35,7 +35,9 @@ func hermitClient(t *testing.T) pb.HermitClient {
 	if os.Getenv("HERMIT_INSECURE") == "true" {
 		opts = append(opts, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	} else {
-		tlsCfg := &tls.Config{InsecureSkipVerify: true} // Self-signed OK for dev/test
+		// Use system CA pool (Cloud Run has valid certs from Google).
+		// Set InsecureSkipVerify only for local dev with self-signed certs.
+		tlsCfg := &tls.Config{}
 		opts = append(opts, grpc.WithTransportCredentials(credentials.NewTLS(tlsCfg)))
 	}
 
@@ -51,9 +53,17 @@ func hermitClient(t *testing.T) pb.HermitClient {
 func hermitCtx(t *testing.T, timeout time.Duration) (context.Context, context.CancelFunc) {
 	t.Helper()
 	ctx := context.Background()
+
+	// App-level auth: x-hermit-secret
 	if secret := os.Getenv("HERMIT_SECRET"); secret != "" {
 		ctx = metadata.AppendToOutgoingContext(ctx, "x-hermit-secret", secret)
 	}
+
+	// Cloud Run IAM auth: bearer token from WIF / gcloud
+	if token := os.Getenv("HERMIT_BEARER_TOKEN"); token != "" {
+		ctx = metadata.AppendToOutgoingContext(ctx, "authorization", "Bearer "+token)
+	}
+
 	return context.WithTimeout(ctx, timeout)
 }
 


### PR DESCRIPTION
## Summary

- Add `.github/workflows/integration-tests-dev.yml` — runs integration tests against deployed Cloud Run dev services
- Triggers automatically after hermit or secrets deploy workflows complete, or via manual dispatch
- Authenticates via WIF, gets IAM identity token for hermit (IAM-gated), reads hermit-secret from GCP Secret Manager
- Update `tests/integration/hermit_test.go`: use system CA pool instead of `InsecureSkipVerify`, add `HERMIT_BEARER_TOKEN` support for Cloud Run IAM auth

## Flow

```
Deploy Hermit/Secrets → workflow_run trigger → Integration Tests
                                                  ├─ WIF auth → identity token + hermit-secret
                                                  ├─ go test -tags integration ./tests/integration/...
                                                  └─ Summary in GitHub Actions
```