### PR TITLE
Deadman terraform: cloud-sql, dns, domain mapping, import

### DIFF
--- a/services/deadman/terraform/environments/dev/.terraform.lock.hcl
+++ b/services/deadman/terraform/environments/dev/.terraform.lock.hcl
@@ -1,0 +1,42 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "5.45.2"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:y2hf6zus1eKA5vpAfoyYkNBKDBQTVqmx4OVh3iRBaRo=",
+    "zh:0d09c8f20b556305192cdbe0efa6d333ceebba963a8ba91f9f1714b5a20c4b7a",
+    "zh:117143fc91be407874568df416b938a6896f94cb873f26bba279cedab646a804",
+    "zh:16ccf77d18dd2c5ef9c0625f9cf546ebdf3213c0a452f432204c69feed55081e",
+    "zh:3e555cf22a570a4bd247964671f421ed7517970cd9765ceb46f335edc2c6f392",
+    "zh:688bd5b05a75124da7ae6e885b2b92bd29f4261808b2b78bd5f51f525c1052ca",
+    "zh:6db3ef37a05010d82900bfffb3261c59a0c247e0692049cb3eb8c2ef16c9d7bf",
+    "zh:70316fde75f6a15d72749f66d994ccbdde5f5ed4311b6d06b99850f698c9bbf9",
+    "zh:84b8e583771a4f2bd514e519d98ed7fd28dce5efe0634e973170e1cfb5556fb4",
+    "zh:9d4b8ef0a9b6677935c604d94495042e68ff5489932cfd1ec41052e094a279d3",
+    "zh:a2089dd9bd825c107b148dd12d6b286f71aa37dfd4ca9c35157f2dcba7bc19d8",
+    "zh:f03d795c0fd9721e59839255ee7ba7414173017dc530b4ce566daf3802a0d6dd",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/google-beta" {
+  version     = "5.45.2"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:r9Tpv9w6j6hTI7MR7zeaUveGsyt/yNXjCmuO80asz98=",
+    "zh:16b77bac5d1555b7f066ba8014f4fc8a6d0de64e252a1988d3fbb400984a4b19",
+    "zh:1b13f515c4809343840aed8265915cc4191f138bdab5a8c5e1f542fdfc69989f",
+    "zh:1dcce4309aeab7c88fd36aea664d57e620d8a413b967ce513a5a866e8de901f2",
+    "zh:24db65d7929f2a731e9cac1750c569cb4528b312ef182a5e2e8c0cf008d8a71b",
+    "zh:28c0b9e68d97570f03b2c4770607701580055bcba50069efd145954aa13b23e4",
+    "zh:3a898a1ad1569f6486a2bc20014087284c8cab919bc8f155833de5128ccd12eb",
+    "zh:4eed99cfb9daada70f813f2cedcf490d3097de1ccb9b391fc451ecc46509c067",
+    "zh:888c4cb1f13b23674ba1091835dd3f1bff5d8e7729ef302183d8d01233819e54",
+    "zh:8baae3b949f6e9505425f5fa4785de786e9cedc4c3f3ad906d8ed560bd2e39c6",
+    "zh:cf2c8928b764592fa2cd14a9f109d01cd0a92049a4fca9d0a74cf2fe588364e2",
+    "zh:edff09394f5bd0b278a4adc800a31b7f150249a1ea92ca273ccf4acd25be3f63",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/services/deadman/terraform/environments/dev/import.sh
+++ b/services/deadman/terraform/environments/dev/import.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# import.sh — Import manually created GCP resources into Terraform state.
+#
+# Run this ONCE from the environments/dev/ directory after `terraform init`.
+# Requires Application Default Credentials with owner/editor access to dea-noctua.
+#
+# Usage:
+#   cd services/deadman/terraform/environments/dev
+#   terraform init
+#   bash import.sh
+#
+# Safe to re-run: terraform import is idempotent (it errors on duplicates but
+# won't corrupt state).
+
+set -euo pipefail
+
+PROJECT="dea-noctua"
+REGION="us-west1"
+INSTANCE="nexus-dev-west1"
+SA="github-actions-ci@dea-noctua.iam.gserviceaccount.com"
+
+echo "==> Importing Cloud SQL instance"
+terraform import \
+  module.cloud_sql.google_sql_database_instance.instance \
+  "projects/${PROJECT}/instances/${INSTANCE}"
+
+echo "==> Importing Cloud SQL database"
+terraform import \
+  module.cloud_sql.google_sql_database.database \
+  "${PROJECT}/${INSTANCE}/deadman"
+
+echo "==> Importing Cloud SQL user"
+terraform import \
+  module.cloud_sql.google_sql_user.user \
+  "${INSTANCE}/deadman"
+
+echo "==> Importing cloudsql.client IAM binding"
+terraform import \
+  module.cloud_sql.google_project_iam_member.cloudsql_client \
+  "${PROJECT} roles/cloudsql.client serviceAccount:${SA}"
+
+echo "==> Importing GCP Secret: deadman-db-password-dev"
+terraform import \
+  module.secrets.google_secret_manager_secret.deadman_db_password \
+  "projects/${PROJECT}/secrets/deadman-db-password-dev"
+
+echo "==> Importing GCP Secret version: deadman-db-password-dev/1"
+terraform import \
+  module.secrets.google_secret_manager_secret_version.deadman_db_password \
+  "projects/${PROJECT}/secrets/deadman-db-password-dev/versions/1"
+
+echo "==> Importing Cloud Run domain mapping: deadman.jredh.com"
+terraform import \
+  module.cloud_run.google_cloud_run_domain_mapping.mapping[0] \
+  "locations/${REGION}/namespaces/${PROJECT}/domainmappings/deadman.jredh.com"
+
+echo "==> Importing Cloud DNS CNAME: deadman.jredh.com"
+terraform import \
+  module.dns.google_dns_record_set.cname \
+  "projects/${PROJECT}/managedZones/jredh-com/rrsets/deadman.jredh.com./CNAME"
+
+echo ""
+echo "All imports complete. Run 'terraform plan' to verify no unexpected diffs."

--- a/services/deadman/terraform/environments/dev/main.tf
+++ b/services/deadman/terraform/environments/dev/main.tf
@@ -1,11 +1,5 @@
 # Nexus Deadman - Development Environment
-# Provisions secrets and Cloud Run service for the deadman switch.
-#
-# NOTE: This module does NOT create a Cloud SQL instance — the deadman
-# service uses a PostgreSQL connection string injected via DATABASE_URL.
-# For dev, this is a Cloud SQL instance you provision separately (or a
-# shared PG instance).  Terraform manages the secret; the DB itself is
-# out of scope here (like portal's Firebase credentials).
+# Provisions Cloud SQL, secrets, DNS, and Cloud Run service for the deadman switch.
 
 terraform {
   required_version = ">= 1.6.0"
@@ -15,11 +9,20 @@ terraform {
       source  = "hashicorp/google"
       version = "~> 5.0"
     }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = "~> 5.0"
+    }
   }
 }
 
 # Provider configuration
 provider "google" {
+  project = var.project_id
+  region  = var.region
+}
+
+provider "google-beta" {
   project = var.project_id
   region  = var.region
 }
@@ -40,19 +43,32 @@ locals {
 
 # Module: GCP Project APIs — reuse portal's project module
 module "project" {
-  source     = "../../../portal/terraform/modules/project"
+  source     = "../../../../portal/terraform/modules/project"
   project_id = var.project_id
 }
 
 # Module: IAM and Workload Identity Federation — reuse portal's IAM module
 module "iam" {
-  source      = "../../../portal/terraform/modules/iam"
+  source      = "../../../../portal/terraform/modules/iam"
   project_id  = var.project_id
   environment = local.environment
   github_org  = local.github_org
   github_repo = local.github_repo
 
   depends_on = [module.project]
+}
+
+# Module: Cloud SQL (PostgreSQL 16, us-west1, shared instance nexus-dev-west1)
+module "cloud_sql" {
+  source                = "../../modules/cloud-sql"
+  project_id            = var.project_id
+  region                = var.region
+  instance_name         = "nexus-dev-west1"
+  database_name         = "deadman"
+  db_user               = "deadman"
+  service_account_email = module.iam.service_account_email
+
+  depends_on = [module.project, module.iam]
 }
 
 # Module: Secret Manager
@@ -70,6 +86,14 @@ module "secrets" {
   depends_on = [module.project, module.iam]
 }
 
+# Module: Cloud DNS — CNAME for deadman.jredh.com
+module "dns" {
+  source        = "../../modules/dns"
+  project_id    = var.project_id
+  dns_zone_name = var.dns_zone_name
+  custom_domain = var.custom_domain
+}
+
 # Module: Cloud Run
 module "cloud_run" {
   source                = "../../modules/cloud-run"
@@ -79,20 +103,26 @@ module "cloud_run" {
   image                 = var.cloud_run_image
   service_account_email = module.iam.service_account_email
 
-  # Non-secret config
+  # Non-secret config.
+  # NOTE: do NOT include PORT here — Cloud Run reserves it.
   environment_variables = {
-    ENVIRONMENT = local.environment
-    PORT        = "8080"
+    ENVIRONMENT               = local.environment
+    CLOUD_SQL_CONNECTION_NAME = module.cloud_sql.connection_name
+    DEADMAN_PUBLIC_URL        = var.deadman_public_url
   }
 
-  # Secrets injected as env vars from Secret Manager
+  # Secrets injected as env vars from Secret Manager.
+  # DEADMAN_DB_PASSWORD is the raw password; entrypoint.sh builds the full DSN.
   secrets = {
-    TWILIO_ACCOUNT_SID = "${module.secrets.twilio_account_sid_secret_id}:latest"
-    TWILIO_AUTH_TOKEN  = "${module.secrets.twilio_auth_token_secret_id}:latest"
-    TWILIO_FROM        = "${module.secrets.twilio_from_secret_id}:latest"
-    DEADMAN_PHONE      = "${module.secrets.deadman_phone_secret_id}:latest"
-    DATABASE_URL       = "${module.secrets.deadman_db_password_secret_id}:latest"
+    TWILIO_ACCOUNT_SID  = "${module.secrets.twilio_account_sid_secret_id}:latest"
+    TWILIO_AUTH_TOKEN   = "${module.secrets.twilio_auth_token_secret_id}:latest"
+    TWILIO_FROM         = "${module.secrets.twilio_from_secret_id}:latest"
+    DEADMAN_PHONE       = "${module.secrets.deadman_phone_secret_id}:latest"
+    DEADMAN_DB_PASSWORD = "${module.secrets.deadman_db_password_secret_id}:latest"
   }
+
+  cloud_sql_connection_name = module.cloud_sql.connection_name
+  custom_domain             = var.custom_domain
 
   memory                = "256Mi"
   cpu                   = "1"
@@ -102,5 +132,5 @@ module "cloud_run" {
 
   labels = local.common_labels
 
-  depends_on = [module.project, module.iam, module.secrets]
+  depends_on = [module.project, module.iam, module.secrets, module.cloud_sql]
 }

--- a/services/deadman/terraform/environments/dev/outputs.tf
+++ b/services/deadman/terraform/environments/dev/outputs.tf
@@ -14,3 +14,13 @@ output "twilio_webhook_url" {
   description = "Full Twilio webhook URL to configure at https://console.twilio.com"
   value       = "${module.cloud_run.service_url}/sms"
 }
+
+output "cloud_sql_connection_name" {
+  description = "Cloud SQL connection name (project:region:instance)"
+  value       = module.cloud_sql.connection_name
+}
+
+output "custom_domain_url" {
+  description = "Public URL via custom domain"
+  value       = "https://${var.custom_domain}"
+}

--- a/services/deadman/terraform/environments/dev/variables.tf
+++ b/services/deadman/terraform/environments/dev/variables.tf
@@ -7,15 +7,33 @@ variable "project_id" {
 }
 
 variable "region" {
-  description = "GCP region"
+  description = "GCP region for all resources (Cloud Run, Cloud SQL, etc.)"
   type        = string
-  default     = "us-central1"
+  default     = "us-west1"
 }
 
 variable "cloud_run_image" {
   description = "Cloud Run container image URL"
   type        = string
   default     = "gcr.io/dea-noctua/nexus-deadman-dev:latest"
+}
+
+variable "custom_domain" {
+  description = "Custom domain for the Cloud Run service"
+  type        = string
+  default     = "deadman.jredh.com"
+}
+
+variable "dns_zone_name" {
+  description = "Cloud DNS managed zone name (resource name, not DNS name)"
+  type        = string
+  default     = "jredh-com"
+}
+
+variable "deadman_public_url" {
+  description = "Public URL of the deadman service (injected as DEADMAN_PUBLIC_URL)"
+  type        = string
+  default     = "https://deadman.jredh.com"
 }
 
 variable "twilio_account_sid" {
@@ -43,7 +61,7 @@ variable "deadman_phone" {
 }
 
 variable "deadman_db_password" {
-  description = "PostgreSQL password for the deadman database"
+  description = "PostgreSQL password for the deadman Cloud SQL user"
   type        = string
   sensitive   = true
 }

--- a/services/deadman/terraform/modules/cloud-run/main.tf
+++ b/services/deadman/terraform/modules/cloud-run/main.tf
@@ -1,10 +1,18 @@
 # Cloud Run Service Configuration for deadman switch
-# Mirrors the portal cloud-run module pattern exactly.
+# Mirrors the portal cloud-run module pattern with additions:
+#   - google-beta provider for domain mapping
+#   - Cloud SQL instance annotation (Unix socket via proxy)
+#   - Optional custom domain mapping
+#   - CLOUD_SQL_CONNECTION_NAME + DEADMAN_PUBLIC_URL env vars
 
 terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
+      version = "~> 5.0"
+    }
+    google-beta = {
+      source  = "hashicorp/google-beta"
       version = "~> 5.0"
     }
   }
@@ -18,7 +26,7 @@ variable "project_id" {
 variable "region" {
   description = "GCP region for Cloud Run service"
   type        = string
-  default     = "us-central1"
+  default     = "us-west1"
 }
 
 variable "service_name" {
@@ -37,7 +45,7 @@ variable "service_account_email" {
 }
 
 variable "environment_variables" {
-  description = "Environment variables for the service"
+  description = "Environment variables for the service (do NOT include PORT — Cloud Run reserves it)"
   type        = map(string)
   default     = {}
 }
@@ -84,7 +92,21 @@ variable "labels" {
   default     = {}
 }
 
+variable "cloud_sql_connection_name" {
+  description = "Cloud SQL connection name (project:region:instance). Empty string disables."
+  type        = string
+  default     = ""
+}
+
+variable "custom_domain" {
+  description = "Custom domain to map to the service (e.g. deadman.jredh.com). Empty string skips."
+  type        = string
+  default     = ""
+}
+
+# -----------------------------------------------------------------------
 # Cloud Run Service
+# -----------------------------------------------------------------------
 resource "google_cloud_run_service" "service" {
   project  = var.project_id
   name     = var.service_name
@@ -98,7 +120,7 @@ resource "google_cloud_run_service" "service" {
         image = var.image
 
         ports {
-          # Deadman listens on PORT env var (default 8095); Cloud Run injects PORT=8080.
+          # Cloud Run injects PORT=8080 at runtime; deadman reads it via os.Getenv("PORT").
           container_port = 8080
         }
 
@@ -109,7 +131,8 @@ resource "google_cloud_run_service" "service" {
           }
         }
 
-        # Plain environment variables
+        # Plain environment variables.
+        # IMPORTANT: do NOT pass PORT here — Cloud Run reserves it and will reject the deploy.
         dynamic "env" {
           for_each = var.environment_variables
           content {
@@ -118,7 +141,7 @@ resource "google_cloud_run_service" "service" {
           }
         }
 
-        # Secrets injected as environment variables from Secret Manager
+        # Secrets injected as environment variables from Secret Manager.
         dynamic "env" {
           for_each = var.secrets
           content {
@@ -137,11 +160,17 @@ resource "google_cloud_run_service" "service" {
     }
 
     metadata {
-      annotations = {
-        "autoscaling.knative.dev/minScale" = tostring(var.min_instances)
-        "autoscaling.knative.dev/maxScale" = tostring(var.max_instances)
-        "run.googleapis.com/client-name"   = "terraform"
-      }
+      annotations = merge(
+        {
+          "autoscaling.knative.dev/minScale" = tostring(var.min_instances)
+          "autoscaling.knative.dev/maxScale" = tostring(var.max_instances)
+          "run.googleapis.com/client-name"   = "terraform"
+        },
+        # Attach Cloud SQL instance so the proxy socket is available in /cloudsql/<connection>.
+        var.cloud_sql_connection_name != "" ? {
+          "run.googleapis.com/cloudsql-instances" = var.cloud_sql_connection_name
+        } : {}
+      )
 
       labels = merge(
         var.labels,
@@ -178,7 +207,35 @@ resource "google_cloud_run_service_iam_member" "public_access" {
   member   = "allUsers"
 }
 
+# -----------------------------------------------------------------------
+# Domain Mapping (google-beta — GA resource not yet stable)
+# Only created when custom_domain is non-empty.
+# -----------------------------------------------------------------------
+resource "google_cloud_run_domain_mapping" "mapping" {
+  count    = var.custom_domain != "" ? 1 : 0
+  provider = google-beta
+
+  project  = var.project_id
+  location = var.region
+  name     = var.custom_domain
+
+  metadata {
+    namespace = var.project_id
+  }
+
+  spec {
+    route_name = google_cloud_run_service.service.name
+  }
+
+  # Domain mapping status changes are driven externally (DNS propagation).
+  lifecycle {
+    ignore_changes = [metadata[0].annotations]
+  }
+}
+
+# -----------------------------------------------------------------------
 # Outputs
+# -----------------------------------------------------------------------
 output "service_url" {
   description = "Cloud Run service URL"
   value       = google_cloud_run_service.service.status[0].url

--- a/services/deadman/terraform/modules/cloud-sql/main.tf
+++ b/services/deadman/terraform/modules/cloud-sql/main.tf
@@ -1,0 +1,123 @@
+# Cloud SQL Module for deadman switch
+# Creates the PostgreSQL instance, database, user, and grants cloudsql.client
+# to the GitHub Actions service account so it can connect at deploy time.
+#
+# Instance: nexus-dev-west1 (shared with other dev services in us-west1)
+# Database: deadman
+# User:     deadman
+
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.0"
+    }
+  }
+}
+
+variable "project_id" {
+  description = "GCP Project ID"
+  type        = string
+}
+
+variable "region" {
+  description = "GCP region for the Cloud SQL instance"
+  type        = string
+  default     = "us-west1"
+}
+
+variable "instance_name" {
+  description = "Cloud SQL instance name"
+  type        = string
+  default     = "nexus-dev-west1"
+}
+
+variable "database_name" {
+  description = "PostgreSQL database name"
+  type        = string
+  default     = "deadman"
+}
+
+variable "db_user" {
+  description = "PostgreSQL user for the deadman service"
+  type        = string
+  default     = "deadman"
+}
+
+variable "service_account_email" {
+  description = "Service account email that needs cloudsql.client (for Cloud Run)"
+  type        = string
+}
+
+# -----------------------------------------------------------------------
+# Cloud SQL Instance — db-f1-micro, Postgres 16, us-west1
+# Shared instance: other dev databases (e.g. portal) may also live here.
+# -----------------------------------------------------------------------
+resource "google_sql_database_instance" "instance" {
+  project          = var.project_id
+  name             = var.instance_name
+  region           = var.region
+  database_version = "POSTGRES_16"
+
+  settings {
+    tier = "db-f1-micro"
+
+    ip_configuration {
+      # No public IP; Cloud Run connects via Unix socket through the Cloud SQL proxy.
+      ipv4_enabled = true # required even for socket-only to allow IAM auth
+    }
+
+    backup_configuration {
+      enabled = true
+    }
+  }
+
+  # Prevent accidental destruction of a shared instance.
+  deletion_protection = true
+}
+
+# -----------------------------------------------------------------------
+# Database
+# -----------------------------------------------------------------------
+resource "google_sql_database" "database" {
+  project  = var.project_id
+  instance = google_sql_database_instance.instance.name
+  name     = var.database_name
+}
+
+# -----------------------------------------------------------------------
+# User
+# Native PG password auth; password is stored in Secret Manager separately.
+# -----------------------------------------------------------------------
+resource "google_sql_user" "user" {
+  project  = var.project_id
+  instance = google_sql_database_instance.instance.name
+  name     = var.db_user
+
+  # Password managed externally (GCP Secret Manager: deadman-db-password-dev).
+  # Terraform does not set it here to avoid storing plaintext in state.
+  # On first run, set the password manually:
+  #   gcloud sql users set-password deadman --instance=nexus-dev-west1 --password=<secret>
+}
+
+# -----------------------------------------------------------------------
+# IAM: cloudsql.client — lets the Cloud Run service connect via socket
+# -----------------------------------------------------------------------
+resource "google_project_iam_member" "cloudsql_client" {
+  project = var.project_id
+  role    = "roles/cloudsql.client"
+  member  = "serviceAccount:${var.service_account_email}"
+}
+
+# -----------------------------------------------------------------------
+# Outputs
+# -----------------------------------------------------------------------
+output "connection_name" {
+  description = "Cloud SQL connection name (project:region:instance)"
+  value       = google_sql_database_instance.instance.connection_name
+}
+
+output "instance_name" {
+  description = "Cloud SQL instance name"
+  value       = google_sql_database_instance.instance.name
+}

--- a/services/deadman/terraform/modules/dns/main.tf
+++ b/services/deadman/terraform/modules/dns/main.tf
@@ -1,0 +1,59 @@
+# DNS Module for deadman switch
+# Creates a CNAME record pointing deadman.jredh.com → ghs.googlehosted.com
+# to back the Cloud Run domain mapping.
+#
+# Prereq: Cloud DNS zone jredh-com must already exist in project dea-noctua.
+
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.0"
+    }
+  }
+}
+
+variable "project_id" {
+  description = "GCP Project ID"
+  type        = string
+}
+
+variable "dns_zone_name" {
+  description = "Cloud DNS managed zone name (not the DNS name — the zone resource name)"
+  type        = string
+  default     = "jredh-com"
+}
+
+variable "custom_domain" {
+  description = "Custom domain for the service (must end without trailing dot)"
+  type        = string
+  default     = "deadman.jredh.com"
+}
+
+variable "cname_target" {
+  description = "CNAME target (Cloud Run domain mapping endpoint)"
+  type        = string
+  default     = "ghs.googlehosted.com."
+}
+
+# -----------------------------------------------------------------------
+# CNAME record: deadman.jredh.com → ghs.googlehosted.com
+# The trailing dot on dns_name is required by Cloud DNS.
+# -----------------------------------------------------------------------
+resource "google_dns_record_set" "cname" {
+  project      = var.project_id
+  managed_zone = var.dns_zone_name
+  name         = "${var.custom_domain}."
+  type         = "CNAME"
+  ttl          = 300
+
+  rrdatas = [var.cname_target]
+}
+
+# -----------------------------------------------------------------------
+# Outputs
+# -----------------------------------------------------------------------
+output "dns_name" {
+  description = "The DNS record name created"
+  value       = google_dns_record_set.cname.name
+}


### PR DESCRIPTION
## Summary

deadman terraform: cloud-sql, dns, domain mapping, import

## Changes

- **Commits**: 24 (will be squashed)
- **Changes**: 16 files changed, 791 insertions(+), 92 deletions(-)

## Files Changed

- `~` .github/workflows/deploy-deadman-dev.yml
- `~` cmd/deadman/Dockerfile
- `+` cmd/deadman/PRIVACY.txt
- `~` cmd/deadman/entrypoint.sh
- `~` cmd/deadman/main.go
- `~` internal/deadman/sms.go
- `+` internal/deadman/test_endpoints.go
- `~` internal/deadman/twilio.go
- `+` services/deadman/terraform/environments/dev/.terraform.lock.hcl
- `+` services/deadman/terraform/environments/dev/import.sh
- `~` services/deadman/terraform/environments/dev/main.tf
- `~` services/deadman/terraform/environments/dev/outputs.tf
- `~` services/deadman/terraform/environments/dev/variables.tf
- `~` services/deadman/terraform/modules/cloud-run/main.tf
- `+` services/deadman/terraform/modules/cloud-sql/main.tf
- `+` services/deadman/terraform/modules/dns/main.tf

---

*Auto-generated from workstream: workstream_deadman-terraform-cloud-sql-dns-domain-mapping-imp-e6b7816b*
