### PR TITLE
Fix terraform plan: remove module.iam/project, data source for SA, lifecycle ignore_changes for cert mode and secret_data

### DIFF
--- a/services/deadman/terraform/environments/dev/main.tf
+++ b/services/deadman/terraform/environments/dev/main.tf
@@ -31,8 +31,6 @@ provider "google-beta" {
 locals {
   environment  = "dev"
   service_name = "nexus-deadman-${local.environment}"
-  github_org   = "jredh-dev"
-  github_repo  = "nexus"
 
   common_labels = {
     app         = "nexus-deadman"
@@ -41,21 +39,12 @@ locals {
   }
 }
 
-# Module: GCP Project APIs — reuse portal's project module
-module "project" {
-  source     = "../../../../portal/terraform/modules/project"
-  project_id = var.project_id
-}
-
-# Module: IAM and Workload Identity Federation — reuse portal's IAM module
-module "iam" {
-  source      = "../../../../portal/terraform/modules/iam"
-  project_id  = var.project_id
-  environment = local.environment
-  github_org  = local.github_org
-  github_repo = local.github_repo
-
-  depends_on = [module.project]
+# Data source: reference the existing github-actions-ci service account.
+# The portal IAM module creates "github-actions-{env}" = "github-actions-dev", which does
+# NOT match the real SA name "github-actions-ci". Using a data source avoids any replacement.
+data "google_service_account" "github_actions" {
+  project    = var.project_id
+  account_id = "github-actions-ci"
 }
 
 # Module: Cloud SQL (PostgreSQL 16, us-west1, shared instance nexus-dev-west1)
@@ -66,9 +55,7 @@ module "cloud_sql" {
   instance_name         = "nexus-dev-west1"
   database_name         = "deadman"
   db_user               = "deadman"
-  service_account_email = module.iam.service_account_email
-
-  depends_on = [module.project, module.iam]
+  service_account_email = data.google_service_account.github_actions.email
 }
 
 # Module: Secret Manager
@@ -76,14 +63,12 @@ module "secrets" {
   source                = "../../modules/secrets"
   project_id            = var.project_id
   environment           = local.environment
-  service_account_email = module.iam.service_account_email
+  service_account_email = data.google_service_account.github_actions.email
   twilio_account_sid    = var.twilio_account_sid
   twilio_auth_token     = var.twilio_auth_token
   twilio_from           = var.twilio_from
   deadman_phone         = var.deadman_phone
   deadman_db_password   = var.deadman_db_password
-
-  depends_on = [module.project, module.iam]
 }
 
 # Module: Cloud DNS — CNAME for deadman.jredh.com
@@ -101,7 +86,7 @@ module "cloud_run" {
   region                = var.region
   service_name          = local.service_name
   image                 = var.cloud_run_image
-  service_account_email = module.iam.service_account_email
+  service_account_email = data.google_service_account.github_actions.email
 
   # Non-secret config.
   # NOTE: do NOT include PORT here — Cloud Run reserves it.
@@ -132,5 +117,5 @@ module "cloud_run" {
 
   labels = local.common_labels
 
-  depends_on = [module.project, module.iam, module.secrets, module.cloud_sql]
+  depends_on = [module.secrets, module.cloud_sql]
 }

--- a/services/deadman/terraform/modules/cloud-run/main.tf
+++ b/services/deadman/terraform/modules/cloud-run/main.tf
@@ -228,8 +228,13 @@ resource "google_cloud_run_domain_mapping" "mapping" {
   }
 
   # Domain mapping status changes are driven externally (DNS propagation).
+  # certificate_mode defaults to AUTOMATIC but is not returned by the API after creation,
+  # causing Terraform to want to replace the resource. Ignore it.
   lifecycle {
-    ignore_changes = [metadata[0].annotations]
+    ignore_changes = [
+      metadata[0].annotations,
+      spec[0].certificate_mode,
+    ]
   }
 }
 

--- a/services/deadman/terraform/modules/secrets/main.tf
+++ b/services/deadman/terraform/modules/secrets/main.tf
@@ -75,6 +75,12 @@ resource "google_secret_manager_secret" "twilio_account_sid" {
 resource "google_secret_manager_secret_version" "twilio_account_sid" {
   secret      = google_secret_manager_secret.twilio_account_sid.id
   secret_data = var.twilio_account_sid
+
+  # Terraform cannot read back secret values to compare — always shows a diff.
+  # Ignore secret_data to prevent forced replacement on every plan.
+  lifecycle {
+    ignore_changes = [secret_data]
+  }
 }
 
 resource "google_secret_manager_secret_iam_member" "twilio_account_sid_access" {
@@ -106,6 +112,10 @@ resource "google_secret_manager_secret" "twilio_auth_token" {
 resource "google_secret_manager_secret_version" "twilio_auth_token" {
   secret      = google_secret_manager_secret.twilio_auth_token.id
   secret_data = var.twilio_auth_token
+
+  lifecycle {
+    ignore_changes = [secret_data]
+  }
 }
 
 resource "google_secret_manager_secret_iam_member" "twilio_auth_token_access" {
@@ -138,6 +148,10 @@ resource "google_secret_manager_secret" "twilio_from" {
 resource "google_secret_manager_secret_version" "twilio_from" {
   secret      = google_secret_manager_secret.twilio_from.id
   secret_data = var.twilio_from
+
+  lifecycle {
+    ignore_changes = [secret_data]
+  }
 }
 
 resource "google_secret_manager_secret_iam_member" "twilio_from_access" {
@@ -169,6 +183,10 @@ resource "google_secret_manager_secret" "deadman_phone" {
 resource "google_secret_manager_secret_version" "deadman_phone" {
   secret      = google_secret_manager_secret.deadman_phone.id
   secret_data = var.deadman_phone
+
+  lifecycle {
+    ignore_changes = [secret_data]
+  }
 }
 
 resource "google_secret_manager_secret_iam_member" "deadman_phone_access" {
@@ -200,6 +218,10 @@ resource "google_secret_manager_secret" "deadman_db_password" {
 resource "google_secret_manager_secret_version" "deadman_db_password" {
   secret      = google_secret_manager_secret.deadman_db_password.id
   secret_data = var.deadman_db_password
+
+  lifecycle {
+    ignore_changes = [secret_data]
+  }
 }
 
 resource "google_secret_manager_secret_iam_member" "deadman_db_password_access" {


### PR DESCRIPTION
## Summary

fix terraform plan: remove module.iam/project, data source for SA, lifecycle ignore_changes for cert mode and secret_data

## Changes

- **Commits**: 35 (will be squashed)
- **Changes**: 17 files changed, 819 insertions(+), 108 deletions(-)

## Files Changed

- `~` .github/workflows/deploy-deadman-dev.yml
- `~` cmd/deadman/Dockerfile
- `+` cmd/deadman/PRIVACY.txt
- `~` cmd/deadman/entrypoint.sh
- `~` cmd/deadman/main.go
- `~` internal/deadman/sms.go
- `+` internal/deadman/test_endpoints.go
- `~` internal/deadman/twilio.go
- `+` services/deadman/terraform/environments/dev/.terraform.lock.hcl
- `+` services/deadman/terraform/environments/dev/import.sh
- `~` services/deadman/terraform/environments/dev/main.tf
- `~` services/deadman/terraform/environments/dev/outputs.tf
- `~` services/deadman/terraform/environments/dev/variables.tf
- `~` services/deadman/terraform/modules/cloud-run/main.tf
- `+` services/deadman/terraform/modules/cloud-sql/main.tf
- `+` services/deadman/terraform/modules/dns/main.tf
- `~` services/deadman/terraform/modules/secrets/main.tf

---

*Auto-generated from workstream: workstream_fix-terraform-plan-remove-module-iam-project-data-560b312f*
