### PR TITLE
Portal account page — user info, email change, delete account

### DIFF
--- a/services/portal/cmd/server/main.go
+++ b/services/portal/cmd/server/main.go
@@ -114,10 +114,19 @@ func main() {
 	r.Post("/signup", h.Signup)
 	r.Get("/logout", h.Logout)
 	r.Get("/auth/magic", h.MagicLogin)
+	r.Get("/auth/email-change", h.ConfirmEmailChange)
 
 	// Public JSON API.
 	r.Route("/api", func(r chi.Router) {
 		r.Get("/actions", h.SearchActions)
+	})
+
+	// Authenticated JSON API — returns 401 JSON (not redirect) on missing session.
+	r.Route("/api/me", func(r chi.Router) {
+		r.Use(handlers.APIAuthMiddleware(authService))
+		r.Get("/", h.GetMe)
+		r.Post("/email", h.ChangeEmail)
+		r.Delete("/", h.DeleteAccount)
 	})
 
 	// Admin routes (login + admin role required).

--- a/services/portal/config/config.go
+++ b/services/portal/config/config.go
@@ -10,6 +10,7 @@ type Config struct {
 	Server  ServerConfig
 	DB      DBConfig
 	Session SessionConfig
+	SMTP    SMTPConfig
 }
 
 // ServerConfig holds HTTP server settings.
@@ -29,6 +30,13 @@ type SessionConfig struct {
 	MaxAge int    // session duration in seconds (default: 7 days)
 }
 
+// SMTPConfig holds outbound email settings.
+type SMTPConfig struct {
+	Host string // SMTP server hostname (e.g. "mailpit" in Docker, "smtp.sendgrid.net" in prod)
+	Port string // SMTP server port (default: "1025" for Mailpit, "587" for prod)
+	From string // From address for outbound email
+}
+
 // Load returns application configuration from environment variables.
 func Load() *Config {
 	return &Config{
@@ -42,6 +50,11 @@ func Load() *Config {
 		Session: SessionConfig{
 			Secret: getEnv("SESSION_SECRET", ""),
 			MaxAge: getEnvInt("SESSION_MAX_AGE", 604800), // 7 days
+		},
+		SMTP: SMTPConfig{
+			Host: getEnv("SMTP_HOST", "localhost"),
+			Port: getEnv("SMTP_PORT", "1025"),
+			From: getEnv("SMTP_FROM", "noreply@jredh.com"),
 		},
 	}
 }

--- a/services/portal/internal/auth/errors.go
+++ b/services/portal/internal/auth/errors.go
@@ -3,13 +3,14 @@ package auth
 import "errors"
 
 var (
-	ErrInvalidCredentials = errors.New("invalid credentials")
-	ErrUserNotFound       = errors.New("user not found")
-	ErrSessionExpired     = errors.New("session expired")
-	ErrUnauthorized       = errors.New("unauthorized")
-	ErrEmailTaken         = errors.New("an account with this email already exists")
-	ErrPhoneTaken         = errors.New("an account with this phone number already exists")
-	ErrUsernameTaken      = errors.New("this username is already taken")
-	ErrInvalidMagicToken  = errors.New("invalid or expired magic login token")
-	ErrForbidden          = errors.New("forbidden: admin access required")
+	ErrInvalidCredentials      = errors.New("invalid credentials")
+	ErrUserNotFound            = errors.New("user not found")
+	ErrSessionExpired          = errors.New("session expired")
+	ErrUnauthorized            = errors.New("unauthorized")
+	ErrEmailTaken              = errors.New("an account with this email already exists")
+	ErrPhoneTaken              = errors.New("an account with this phone number already exists")
+	ErrUsernameTaken           = errors.New("this username is already taken")
+	ErrInvalidMagicToken       = errors.New("invalid or expired magic login token")
+	ErrForbidden               = errors.New("forbidden: admin access required")
+	ErrInvalidEmailChangeToken = errors.New("invalid or expired email change token")
 )

--- a/services/portal/internal/auth/service.go
+++ b/services/portal/internal/auth/service.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/jredh-dev/nexus/services/portal/config"
 	"github.com/jredh-dev/nexus/services/portal/internal/database"
+	"github.com/jredh-dev/nexus/services/portal/internal/mailer"
 	"github.com/jredh-dev/nexus/services/portal/pkg/identity"
 	"github.com/jredh-dev/nexus/services/portal/pkg/models"
 	"golang.org/x/crypto/bcrypt"
@@ -18,13 +19,15 @@ const bcryptCost = 12
 
 // Service handles authentication operations.
 type Service struct {
-	db  *database.DB
-	cfg *config.Config
+	db     *database.DB
+	cfg    *config.Config
+	mailer *mailer.Mailer
 }
 
 // New creates a new auth service.
 func New(db *database.DB, cfg *config.Config) *Service {
-	return &Service{db: db, cfg: cfg}
+	m := mailer.New(cfg.SMTP.Host, cfg.SMTP.Port, cfg.SMTP.From)
+	return &Service{db: db, cfg: cfg, mailer: m}
 }
 
 // HashPassword hashes a plaintext password with bcrypt.
@@ -293,4 +296,95 @@ func (s *Service) ValidateMagicToken(token, ipAddress, userAgent string) (string
 	}
 
 	return session.ID, nil
+}
+
+// --- Email change operations ---
+
+const emailChangeTokenExpiry = 15 * time.Minute
+
+// InitiateEmailChange sends a verification email to newEmail containing a
+// one-time-use token. The email change is not applied until ConfirmEmailChange
+// is called with the token.
+//
+// baseURL should be the scheme+host used to build the confirmation link,
+// e.g. "https://portal.jredh.com" or "http://localhost:8090".
+func (s *Service) InitiateEmailChange(userID, newEmail, baseURL string) error {
+	// Verify the user exists.
+	user, err := s.db.GetUserByID(userID)
+	if err != nil {
+		return fmt.Errorf("lookup user: %w", err)
+	}
+	if user == nil {
+		return ErrUserNotFound
+	}
+
+	// Reject if new email is already taken by another account.
+	newHash := identity.EmailHash(newEmail)
+	existing, err := s.db.GetUserByEmailHash(newHash)
+	if err != nil {
+		return fmt.Errorf("check email hash: %w", err)
+	}
+	if existing != nil && existing.ID != userID {
+		return ErrEmailTaken
+	}
+
+	// Generate cryptographically secure token.
+	tokenBytes := make([]byte, magicTokenBytes) // reuse same 32-byte constant
+	if _, err := rand.Read(tokenBytes); err != nil {
+		return fmt.Errorf("generate token: %w", err)
+	}
+	token := hex.EncodeToString(tokenBytes)
+
+	now := time.Now()
+	ect := &models.EmailChangeToken{
+		ID:        token,
+		UserID:    userID,
+		NewEmail:  newEmail,
+		ExpiresAt: now.Add(emailChangeTokenExpiry),
+		CreatedAt: now,
+	}
+	if err := s.db.CreateEmailChangeToken(ect); err != nil {
+		return fmt.Errorf("store email change token: %w", err)
+	}
+
+	// Send confirmation email to the NEW address.
+	link := fmt.Sprintf("%s/auth/email-change?token=%s", baseURL, token)
+	if err := s.mailer.SendEmailChangeVerification(newEmail, link); err != nil {
+		return fmt.Errorf("send verification email: %w", err)
+	}
+
+	return nil
+}
+
+// ConfirmEmailChange consumes the token and updates the user's email address.
+// Returns the userID of the affected account so the caller can refresh session context.
+func (s *Service) ConfirmEmailChange(token string) (string, error) {
+	ect, err := s.db.GetEmailChangeToken(token)
+	if err != nil {
+		return "", fmt.Errorf("get email change token: %w", err)
+	}
+	if ect == nil {
+		return "", ErrInvalidEmailChangeToken
+	}
+
+	// Consume first — prevent double-use even if the update below fails.
+	if err := s.db.ConsumeEmailChangeToken(token); err != nil {
+		return "", fmt.Errorf("consume email change token: %w", err)
+	}
+
+	newHash := identity.EmailHash(ect.NewEmail)
+	if err := s.db.UpdateUserEmail(ect.UserID, ect.NewEmail, newHash); err != nil {
+		return "", fmt.Errorf("update user email: %w", err)
+	}
+
+	return ect.UserID, nil
+}
+
+// DeleteAccount deletes the user and all associated sessions/tokens.
+// The caller should clear the session cookie after this returns.
+func (s *Service) DeleteAccount(userID string) error {
+	if err := s.db.DeleteUser(userID); err != nil {
+		return fmt.Errorf("delete user: %w", err)
+	}
+	return nil
 }

--- a/services/portal/internal/database/database.go
+++ b/services/portal/internal/database/database.go
@@ -81,6 +81,17 @@ func migrate(conn *sql.DB) error {
 	);
 
 	CREATE INDEX IF NOT EXISTS idx_magic_tokens_user_id ON magic_tokens(user_id);
+
+	CREATE TABLE IF NOT EXISTS email_change_tokens (
+		id         TEXT PRIMARY KEY,
+		user_id    TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+		new_email  TEXT NOT NULL,
+		expires_at DATETIME NOT NULL,
+		used_at    DATETIME,
+		created_at DATETIME NOT NULL
+	);
+
+	CREATE INDEX IF NOT EXISTS idx_email_change_tokens_user_id ON email_change_tokens(user_id);
 	`
 	if _, err := conn.Exec(ddl); err != nil {
 		return err
@@ -290,5 +301,54 @@ func (db *DB) ConsumeMagicToken(id string) error {
 func (db *DB) DeleteExpiredMagicTokens() error {
 	const q = `DELETE FROM magic_tokens WHERE expires_at <= ? OR used_at IS NOT NULL`
 	_, err := db.conn.Exec(q, time.Now())
+	return err
+}
+
+// --- Email change token operations ---
+
+// CreateEmailChangeToken inserts a new email-change verification token.
+func (db *DB) CreateEmailChangeToken(t *models.EmailChangeToken) error {
+	const q = `INSERT INTO email_change_tokens (id, user_id, new_email, expires_at, created_at)
+	           VALUES (?, ?, ?, ?, ?)`
+	_, err := db.conn.Exec(q, t.ID, t.UserID, t.NewEmail, t.ExpiresAt, t.CreatedAt)
+	return err
+}
+
+// GetEmailChangeToken retrieves an email-change token by ID if it is unused and not expired.
+func (db *DB) GetEmailChangeToken(id string) (*models.EmailChangeToken, error) {
+	const q = `SELECT id, user_id, new_email, expires_at, created_at
+	           FROM email_change_tokens WHERE id = ? AND used_at IS NULL AND expires_at > ?`
+	t := &models.EmailChangeToken{}
+	err := db.conn.QueryRow(q, id, time.Now()).Scan(&t.ID, &t.UserID, &t.NewEmail, &t.ExpiresAt, &t.CreatedAt)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	return t, err
+}
+
+// ConsumeEmailChangeToken marks an email-change token as used.
+func (db *DB) ConsumeEmailChangeToken(id string) error {
+	const q = `UPDATE email_change_tokens SET used_at = ? WHERE id = ?`
+	_, err := db.conn.Exec(q, time.Now(), id)
+	return err
+}
+
+// DeleteExpiredEmailChangeTokens cleans up tokens that have expired or been used.
+func (db *DB) DeleteExpiredEmailChangeTokens() error {
+	const q = `DELETE FROM email_change_tokens WHERE expires_at <= ? OR used_at IS NOT NULL`
+	_, err := db.conn.Exec(q, time.Now())
+	return err
+}
+
+// UpdateUserEmail updates a user's email and email hash.
+func (db *DB) UpdateUserEmail(userID, newEmail, newEmailHash string) error {
+	const q = `UPDATE users SET email = ?, email_hash = ?, updated_at = ? WHERE id = ?`
+	_, err := db.conn.Exec(q, newEmail, newEmailHash, time.Now(), userID)
+	return err
+}
+
+// DeleteUser deletes a user by ID (cascades to sessions and tokens).
+func (db *DB) DeleteUser(userID string) error {
+	_, err := db.conn.Exec(`DELETE FROM users WHERE id = ?`, userID)
 	return err
 }

--- a/services/portal/internal/mailer/mailer.go
+++ b/services/portal/internal/mailer/mailer.go
@@ -1,0 +1,67 @@
+// Package mailer provides a minimal SMTP client for sending transactional email.
+// It uses only the standard library net/smtp — no external dependencies.
+// In local development, point SMTP_HOST/SMTP_PORT at Mailpit (localhost:1025)
+// so emails are captured in the Mailpit UI at http://localhost:8025.
+package mailer
+
+import (
+	"fmt"
+	"net/smtp"
+	"strings"
+)
+
+// Mailer sends transactional email via SMTP.
+type Mailer struct {
+	host string // SMTP hostname (e.g. "mailpit" in Docker)
+	port string // SMTP port (e.g. "1025" for Mailpit, "587" for prod)
+	from string // From address for all outbound mail
+}
+
+// New creates a new Mailer. host and port are read from config (SMTP_HOST / SMTP_PORT).
+func New(host, port, from string) *Mailer {
+	return &Mailer{host: host, port: port, from: from}
+}
+
+// SendEmailChangeVerification sends a verification link to the new email address.
+// The recipient must click the link to confirm the address change.
+// link should be the full URL: https://host/auth/email-change?token=X
+func (m *Mailer) SendEmailChangeVerification(to, link string) error {
+	subject := "Confirm your new email address"
+	body := strings.Join([]string{
+		"Hello,",
+		"",
+		"A request was made to change the email address associated with your account.",
+		"Click the link below to confirm your new email address:",
+		"",
+		link,
+		"",
+		"This link expires in 15 minutes and can only be used once.",
+		"If you did not request this change, you can ignore this email.",
+		"",
+		"— nexus",
+	}, "\r\n")
+
+	return m.send(to, subject, body)
+}
+
+// send is the low-level SMTP delivery method. It builds a minimal RFC 5322
+// message and sends it to host:port. Authentication is deliberately omitted —
+// Mailpit and most internal relays don't require it. For prod with a real SMTP
+// relay that needs auth, extend this with smtp.PlainAuth.
+func (m *Mailer) send(to, subject, body string) error {
+	addr := fmt.Sprintf("%s:%s", m.host, m.port)
+
+	// Build raw message headers + body.
+	// net/smtp.SendMail expects the full message including headers.
+	msg := fmt.Sprintf(
+		"From: %s\r\nTo: %s\r\nSubject: %s\r\nMIME-Version: 1.0\r\nContent-Type: text/plain; charset=UTF-8\r\n\r\n%s",
+		m.from, to, subject, body,
+	)
+
+	// No auth — Mailpit and internal relays don't need it.
+	// For authenticated SMTP, pass smtp.PlainAuth here.
+	if err := smtp.SendMail(addr, nil, m.from, []string{to}, []byte(msg)); err != nil {
+		return fmt.Errorf("smtp send to %s: %w", to, err)
+	}
+	return nil
+}

--- a/services/portal/internal/web/handlers/handlers.go
+++ b/services/portal/internal/web/handlers/handlers.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/jredh-dev/nexus/services/portal/config"
 	"github.com/jredh-dev/nexus/services/portal/internal/actions"
@@ -298,6 +299,173 @@ func (h *Handler) SearchActions(w http.ResponseWriter, r *http.Request) {
 	if err := json.NewEncoder(w).Encode(results); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 	}
+}
+
+// GetMe returns the authenticated user's profile as JSON.
+//
+//	@Summary      Get current user
+//	@Description  Returns the authenticated user's profile. Requires session cookie.
+//	@Tags         account
+//	@Produce      json
+//	@Success      200  {object}  map[string]interface{}
+//	@Failure      401  {object}  map[string]string
+//	@Router       /api/me [get]
+func (h *Handler) GetMe(w http.ResponseWriter, r *http.Request) {
+	user, ok := GetUserFromContext(r.Context())
+	if !ok || user == nil {
+		h.jsonError(w, "authentication required", http.StatusUnauthorized)
+		return
+	}
+
+	type meResponse struct {
+		ID          string    `json:"id"`
+		Email       string    `json:"email"`
+		Username    string    `json:"username"`
+		Name        string    `json:"name"`
+		IsAdmin     bool      `json:"is_admin"`
+		IsActive    bool      `json:"is_active"`
+		CreatedAt   time.Time `json:"created_at"`
+		LastLoginAt time.Time `json:"last_login_at"`
+	}
+
+	resp := meResponse{
+		ID:          user.ID,
+		Email:       user.Email,
+		Username:    user.Username,
+		Name:        user.Name,
+		IsAdmin:     user.IsAdmin(),
+		IsActive:    user.Role != "",
+		CreatedAt:   user.CreatedAt,
+		LastLoginAt: user.LastLoginAt,
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(resp); err != nil {
+		log.Printf("GetMe encode error: %v", err)
+	}
+}
+
+// ChangeEmail initiates an email address change by sending a verification link
+// to the requested new address. The change is not applied until the link is clicked.
+//
+//	@Summary      Request email change
+//	@Description  Sends a verification link to the new email. Change applies on confirmation.
+//	@Tags         account
+//	@Accept       json
+//	@Produce      json
+//	@Param        body  body  map[string]string  true  "new_email"
+//	@Success      200  {object}  map[string]string
+//	@Failure      400  {object}  map[string]string
+//	@Failure      401  {object}  map[string]string
+//	@Router       /api/me/email [post]
+func (h *Handler) ChangeEmail(w http.ResponseWriter, r *http.Request) {
+	user, ok := GetUserFromContext(r.Context())
+	if !ok || user == nil {
+		h.jsonError(w, "authentication required", http.StatusUnauthorized)
+		return
+	}
+
+	var body struct {
+		NewEmail string `json:"new_email"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		h.jsonError(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+	body.NewEmail = strings.TrimSpace(strings.ToLower(body.NewEmail))
+	if body.NewEmail == "" {
+		h.jsonError(w, "new_email is required", http.StatusBadRequest)
+		return
+	}
+
+	// Build the base URL for the confirmation link from the incoming request.
+	scheme := "https"
+	if h.cfg.Server.Env != "production" {
+		scheme = "http"
+	}
+	baseURL := fmt.Sprintf("%s://%s", scheme, r.Host)
+
+	if err := h.auth.InitiateEmailChange(user.ID, body.NewEmail, baseURL); err != nil {
+		log.Printf("InitiateEmailChange for user %s: %v", user.ID, err)
+		if errors.Is(err, auth.ErrEmailTaken) {
+			h.jsonError(w, "That email address is already in use.", http.StatusConflict)
+			return
+		}
+		h.jsonError(w, "Failed to send verification email. Please try again.", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	fmt.Fprintf(w, `{"message":"Verification email sent to %s. Click the link to confirm your new address."}`, body.NewEmail)
+}
+
+// ConfirmEmailChange handles GET /auth/email-change?token=X.
+// Validates the token, updates the user's email, and redirects to /account.
+//
+//	@Summary      Confirm email change
+//	@Description  Validates a one-time email-change token and updates the user's email.
+//	@Tags         account
+//	@Param        token  query  string  true  "Email change token"
+//	@Success      303  "Redirect to /account?success=email-changed"
+//	@Failure      400  {string}  string  "Missing token"
+//	@Failure      401  {string}  string  "Invalid or expired token"
+//	@Router       /auth/email-change [get]
+func (h *Handler) ConfirmEmailChange(w http.ResponseWriter, r *http.Request) {
+	token := r.URL.Query().Get("token")
+	if token == "" {
+		http.Error(w, "Missing token", http.StatusBadRequest)
+		return
+	}
+
+	_, err := h.auth.ConfirmEmailChange(token)
+	if err != nil {
+		log.Printf("ConfirmEmailChange: %v", err)
+		if errors.Is(err, auth.ErrInvalidEmailChangeToken) {
+			http.Error(w, "Invalid or expired email change link.", http.StatusUnauthorized)
+			return
+		}
+		http.Error(w, "Internal server error", http.StatusInternalServerError)
+		return
+	}
+
+	http.Redirect(w, r, "/account?success=email-changed", http.StatusSeeOther)
+}
+
+// DeleteAccount deletes the authenticated user's account, clears their session
+// cookie, and redirects to /.
+//
+//	@Summary      Delete account
+//	@Description  Permanently deletes the authenticated user's account and all sessions.
+//	@Tags         account
+//	@Success      200  {object}  map[string]string
+//	@Failure      401  {object}  map[string]string
+//	@Router       /api/me [delete]
+func (h *Handler) DeleteAccount(w http.ResponseWriter, r *http.Request) {
+	user, ok := GetUserFromContext(r.Context())
+	if !ok || user == nil {
+		h.jsonError(w, "authentication required", http.StatusUnauthorized)
+		return
+	}
+
+	if err := h.auth.DeleteAccount(user.ID); err != nil {
+		log.Printf("DeleteAccount for user %s: %v", user.ID, err)
+		h.jsonError(w, "Failed to delete account. Please try again.", http.StatusInternalServerError)
+		return
+	}
+
+	// Clear session cookie — the DB rows are already gone via CASCADE.
+	http.SetCookie(w, &http.Cookie{
+		Name:     "session",
+		Value:    "",
+		Path:     "/",
+		MaxAge:   -1,
+		HttpOnly: true,
+		Secure:   h.cfg.Server.Env == "production",
+		SameSite: http.SameSiteLaxMode,
+	})
+
+	w.Header().Set("Content-Type", "application/json")
+	fmt.Fprintf(w, `{"message":"Account deleted."}`)
 }
 
 // --- helpers ---

--- a/services/portal/internal/web/handlers/middleware.go
+++ b/services/portal/internal/web/handlers/middleware.go
@@ -65,6 +65,43 @@ func AdminMiddleware(next http.Handler) http.Handler {
 	})
 }
 
+// APIAuthMiddleware requires a valid session cookie, returning JSON 401 on
+// failure instead of an HTML redirect. Use this on /api/* routes that are
+// called by the Astro frontend via fetch(), not by browser navigation.
+func APIAuthMiddleware(authService *auth.Service) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			cookie, err := r.Cookie("session")
+			if err != nil || cookie.Value == "" {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusUnauthorized)
+				w.Write([]byte(`{"error":"authentication required"}`))
+				return
+			}
+
+			user, _, err := authService.ValidateSession(cookie.Value)
+			if err != nil {
+				log.Printf("API session validation error: %v", err)
+				clearSessionCookie(w)
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusUnauthorized)
+				w.Write([]byte(`{"error":"authentication required"}`))
+				return
+			}
+			if user == nil {
+				clearSessionCookie(w)
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusUnauthorized)
+				w.Write([]byte(`{"error":"authentication required"}`))
+				return
+			}
+
+			ctx := context.WithValue(r.Context(), UserContextKey, user)
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	}
+}
+
 // GetUserFromContext extracts the authenticated user from request context.
 func GetUserFromContext(ctx context.Context) (*models.User, bool) {
 	user, ok := ctx.Value(UserContextKey).(*models.User)

--- a/services/portal/pkg/models/models.go
+++ b/services/portal/pkg/models/models.go
@@ -47,3 +47,14 @@ type MagicToken struct {
 	UsedAt    time.Time `json:"used_at,omitempty"`
 	CreatedAt time.Time `json:"created_at"`
 }
+
+// EmailChangeToken represents a one-time-use token for verifying an email change.
+// The token is sent to the new address; on click, the user's email is updated.
+type EmailChangeToken struct {
+	ID        string    `json:"id"`
+	UserID    string    `json:"user_id"`
+	NewEmail  string    `json:"new_email"`
+	ExpiresAt time.Time `json:"expires_at"`
+	UsedAt    time.Time `json:"used_at,omitempty"`
+	CreatedAt time.Time `json:"created_at"`
+}

--- a/services/portal/tests/integration/account_test.go
+++ b/services/portal/tests/integration/account_test.go
@@ -1,0 +1,624 @@
+//go:build integration
+
+package integration
+
+// Email change and account management integration tests.
+//
+// These tests require:
+//   - Mailpit running with SMTP on localhost:1025 and HTTP API on localhost:8025
+//     (or the addresses configured via MAILPIT_SMTP_HOST/PORT and MAILPIT_URL)
+//   - The portal SMTP config pointing at that Mailpit instance
+//
+// Run with:
+//
+//	go test -tags integration ./services/portal/tests/integration/... -run TestAccount -v
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/cookiejar"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/jredh-dev/nexus/services/portal/config"
+	"github.com/jredh-dev/nexus/services/portal/internal/actions"
+	"github.com/jredh-dev/nexus/services/portal/internal/auth"
+	"github.com/jredh-dev/nexus/services/portal/internal/database"
+	"github.com/jredh-dev/nexus/services/portal/internal/web/handlers"
+)
+
+// --- Mailpit helpers ---
+
+// mailpitURL returns the base URL for the Mailpit HTTP API.
+func mailpitURL() string {
+	if u := os.Getenv("MAILPIT_URL"); u != "" {
+		return strings.TrimRight(u, "/")
+	}
+	return "http://localhost:8025"
+}
+
+// mailpitSMTPHost returns the SMTP host for Mailpit.
+func mailpitSMTPHost() string {
+	if h := os.Getenv("MAILPIT_SMTP_HOST"); h != "" {
+		return h
+	}
+	return "localhost"
+}
+
+// mailpitSMTPPort returns the SMTP port for Mailpit.
+func mailpitSMTPPort() string {
+	if p := os.Getenv("MAILPIT_SMTP_PORT"); p != "" {
+		return p
+	}
+	return "1025"
+}
+
+// purgeMailpit deletes all messages from Mailpit before a test run.
+func purgeMailpit(t *testing.T) {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodDelete, mailpitURL()+"/api/v1/messages", nil)
+	if err != nil {
+		t.Fatalf("mailpit purge request: %v", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("mailpit purge: %v (is Mailpit running at %s?)", err, mailpitURL())
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("mailpit purge status = %d, want 200", resp.StatusCode)
+	}
+}
+
+// mailpitMessage is the summary shape returned by GET /api/v1/messages.
+type mailpitMessage struct {
+	ID      string `json:"ID"`
+	Subject string `json:"Subject"`
+	To      []struct {
+		Address string `json:"Address"`
+	} `json:"To"`
+}
+
+// mailpitListResponse is the top-level shape of GET /api/v1/messages.
+type mailpitListResponse struct {
+	Messages []mailpitMessage `json:"messages"`
+	Total    int              `json:"total"`
+}
+
+// mailpitFullMessage is the shape returned by GET /api/v1/message/{id}.
+type mailpitFullMessage struct {
+	ID   string `json:"ID"`
+	Text string `json:"Text"`
+}
+
+// waitForMail polls Mailpit until at least one message arrives addressed to
+// toAddr, or the timeout is reached. Returns the first matching message.
+func waitForMail(t *testing.T, toAddr string, timeout time.Duration) mailpitMessage {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		resp, err := http.Get(mailpitURL() + "/api/v1/messages")
+		if err != nil {
+			t.Fatalf("mailpit list: %v", err)
+		}
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+
+		var list mailpitListResponse
+		if err := json.Unmarshal(body, &list); err != nil {
+			t.Fatalf("mailpit list unmarshal: %v (body: %s)", err, string(body))
+		}
+
+		for _, msg := range list.Messages {
+			for _, to := range msg.To {
+				if strings.EqualFold(to.Address, toAddr) {
+					return msg
+				}
+			}
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for email to %s (mailpit at %s)", toAddr, mailpitURL())
+	return mailpitMessage{} // unreachable
+}
+
+// fetchMailText fetches the plain-text body of a Mailpit message by ID.
+func fetchMailText(t *testing.T, msgID string) string {
+	t.Helper()
+	resp, err := http.Get(mailpitURL() + "/api/v1/message/" + msgID)
+	if err != nil {
+		t.Fatalf("mailpit fetch message %s: %v", msgID, err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+
+	var full mailpitFullMessage
+	if err := json.Unmarshal(body, &full); err != nil {
+		t.Fatalf("mailpit message unmarshal: %v (body: %s)", err, string(body))
+	}
+	return full.Text
+}
+
+// extractConfirmURL finds the first http(s) URL in text that contains the path
+// /auth/email-change. This is the confirmation link we sent in the email.
+func extractConfirmURL(t *testing.T, text string) string {
+	t.Helper()
+	re := regexp.MustCompile(`https?://[^\s]+/auth/email-change\?token=[^\s]+`)
+	match := re.FindString(text)
+	if match == "" {
+		t.Fatalf("no /auth/email-change link found in email body:\n%s", text)
+	}
+	return match
+}
+
+// --- Test server with account routes ---
+
+// testServerWithAccount spins up a full portal stack wired with the account
+// management routes, pointing SMTP at local Mailpit.
+func testServerWithAccount(t *testing.T) (srv *httptest.Server, client *http.Client, db *database.DB, authSvc *auth.Service, cleanup func()) {
+	t.Helper()
+
+	root := findMonorepoRoot(t)
+	origDir, _ := os.Getwd()
+	if err := os.Chdir(root); err != nil {
+		t.Fatalf("chdir to monorepo root: %v", err)
+	}
+
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+
+	var err error
+	db, err = database.New(dbPath)
+	if err != nil {
+		t.Fatalf("open test db: %v", err)
+	}
+
+	cfg := &config.Config{
+		Server:  config.ServerConfig{Port: "0", Env: "test"},
+		DB:      config.DBConfig{Path: dbPath},
+		Session: config.SessionConfig{Secret: "test-secret", MaxAge: 3600},
+		SMTP: config.SMTPConfig{
+			Host: mailpitSMTPHost(),
+			Port: mailpitSMTPPort(),
+			From: "noreply@test.local",
+		},
+	}
+
+	authSvc = auth.New(db, cfg)
+	h := handlers.New(db, cfg, authSvc, actions.New())
+
+	r := chi.NewRouter()
+	r.Post("/login", h.Login)
+	r.Post("/signup", h.Signup)
+	r.Get("/logout", h.Logout)
+	r.Get("/auth/magic", h.MagicLogin)
+	r.Get("/auth/email-change", h.ConfirmEmailChange)
+	r.Get("/api/actions", h.SearchActions)
+	r.Route("/api/me", func(r chi.Router) {
+		r.Use(handlers.APIAuthMiddleware(authSvc))
+		r.Get("/", h.GetMe)
+		r.Post("/email", h.ChangeEmail)
+		r.Delete("/", h.DeleteAccount)
+	})
+	r.Group(func(r chi.Router) {
+		r.Use(handlers.AuthMiddleware(authSvc))
+		r.Use(handlers.AdminMiddleware)
+		r.Post("/admin/magic-link", h.AdminGenerateMagicLink)
+	})
+
+	srv = httptest.NewServer(r)
+
+	jar, _ := cookiejar.New(nil)
+	client = &http.Client{
+		Jar: jar,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			if len(via) >= 10 {
+				return http.ErrUseLastResponse
+			}
+			return nil
+		},
+	}
+
+	cleanup = func() {
+		srv.Close()
+		db.Close()
+		_ = os.Chdir(origDir)
+	}
+	return srv, client, db, authSvc, cleanup
+}
+
+// --- Tests ---
+
+// TestGetMe_Unauthenticated checks that GET /api/me returns 401 JSON when no
+// session is present (not an HTML redirect, which would break fetch() callers).
+func TestGetMe_Unauthenticated(t *testing.T) {
+	srv, _, _, _, cleanup := testServerWithAccount(t)
+	defer cleanup()
+
+	jar, _ := cookiejar.New(nil)
+	bare := &http.Client{
+		Jar: jar,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+
+	resp, err := bare.Get(srv.URL + "/api/me/")
+	if err != nil {
+		t.Fatalf("GET /api/me/: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("unauthenticated GET /api/me/: status = %d, want 401", resp.StatusCode)
+	}
+	ct := resp.Header.Get("Content-Type")
+	if !strings.HasPrefix(ct, "application/json") {
+		t.Errorf("Content-Type = %q, want application/json", ct)
+	}
+}
+
+// TestGetMe_Authenticated verifies the profile endpoint returns correct fields
+// after a signup+login.
+func TestGetMe_Authenticated(t *testing.T) {
+	srv, client, _, _, cleanup := testServerWithAccount(t)
+	defer cleanup()
+
+	signupAndLogin(t, client, srv.URL, "meuser", "me@example.com", "5550000100", "password", "Me User")
+
+	resp, err := client.Get(srv.URL + "/api/me/")
+	if err != nil {
+		t.Fatalf("GET /api/me/: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("GET /api/me/ status = %d, body: %s", resp.StatusCode, body)
+	}
+
+	var profile struct {
+		Email    string `json:"email"`
+		Username string `json:"username"`
+		IsAdmin  bool   `json:"is_admin"`
+		IsActive bool   `json:"is_active"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&profile); err != nil {
+		t.Fatalf("decode /api/me/ response: %v", err)
+	}
+	if profile.Email != "me@example.com" {
+		t.Errorf("email = %q, want me@example.com", profile.Email)
+	}
+	if profile.Username != "meuser" {
+		t.Errorf("username = %q, want meuser", profile.Username)
+	}
+	if profile.IsAdmin {
+		t.Error("is_admin = true, want false for regular user")
+	}
+	if !profile.IsActive {
+		t.Error("is_active = false, want true for user with a role")
+	}
+}
+
+// TestEmailChange_FullFlow is the main workflow test:
+//  1. Sign up + log in
+//  2. POST /api/me/email → portal sends verification email via Mailpit SMTP
+//  3. Poll Mailpit HTTP API to retrieve the email
+//  4. Extract the confirmation link from the email body
+//  5. Rewrite the link to point at the httptest server and GET it
+//  6. Verify portal redirects to /account?success=email-changed
+//  7. Confirm the DB now stores the new email via GET /api/me
+func TestEmailChange_FullFlow(t *testing.T) {
+	srv, client, _, _, cleanup := testServerWithAccount(t)
+	defer cleanup()
+	purgeMailpit(t)
+
+	const (
+		originalEmail = "original@example.com"
+		newEmail      = "new-address@example.com"
+	)
+
+	signupAndLogin(t, client, srv.URL, "changeuser", originalEmail, "5550000200", "password", "Change User")
+
+	// Request email change — portal should dispatch to Mailpit SMTP.
+	reqBody, _ := json.Marshal(map[string]string{"new_email": newEmail})
+	resp, err := client.Post(srv.URL+"/api/me/email", "application/json", bytes.NewReader(reqBody))
+	if err != nil {
+		t.Fatalf("POST /api/me/email: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("POST /api/me/email status = %d, body: %s", resp.StatusCode, body)
+	}
+
+	// Poll Mailpit for the verification email (up to 5 seconds).
+	msg := waitForMail(t, newEmail, 5*time.Second)
+	if !strings.Contains(msg.Subject, "Confirm") {
+		t.Errorf("subject = %q, want something containing 'Confirm'", msg.Subject)
+	}
+
+	// Fetch full message body and extract the confirmation link.
+	text := fetchMailText(t, msg.ID)
+	confirmURL := extractConfirmURL(t, text)
+
+	// The link was built with the httptest server's host, so we can hit it directly.
+	// Parse it to ensure we call the test server, not some other host.
+	parsed, err := url.Parse(confirmURL)
+	if err != nil {
+		t.Fatalf("parse confirm URL %q: %v", confirmURL, err)
+	}
+	srvParsed, _ := url.Parse(srv.URL)
+	parsed.Scheme = srvParsed.Scheme
+	parsed.Host = srvParsed.Host
+	localConfirm := parsed.String()
+
+	// A fresh client (no session) hits the confirmation link.
+	confirmJar, _ := cookiejar.New(nil)
+	confirmClient := &http.Client{
+		Jar: confirmJar,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			if len(via) >= 10 {
+				return http.ErrUseLastResponse
+			}
+			return nil
+		},
+	}
+	resp, err = confirmClient.Get(localConfirm)
+	if err != nil {
+		t.Fatalf("GET confirm link: %v", err)
+	}
+	resp.Body.Close()
+
+	// Portal should redirect to /account?success=email-changed.
+	if !strings.Contains(resp.Request.URL.String(), "success=email-changed") {
+		t.Errorf("after confirm, landed on %s, want /account?success=email-changed", resp.Request.URL)
+	}
+
+	// Verify the email was actually updated — original session should reflect new email.
+	resp, err = client.Get(srv.URL + "/api/me/")
+	if err != nil {
+		t.Fatalf("GET /api/me/ after email change: %v", err)
+	}
+	defer resp.Body.Close()
+
+	var profile struct {
+		Email string `json:"email"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&profile); err != nil {
+		t.Fatalf("decode /api/me/: %v", err)
+	}
+	if profile.Email != newEmail {
+		t.Errorf("after email change: email = %q, want %q", profile.Email, newEmail)
+	}
+}
+
+// TestEmailChange_TokenCannotBeReused verifies the confirmation link is one-time-use.
+func TestEmailChange_TokenCannotBeReused(t *testing.T) {
+	srv, client, _, _, cleanup := testServerWithAccount(t)
+	defer cleanup()
+	purgeMailpit(t)
+
+	signupAndLogin(t, client, srv.URL, "reuseuser", "reuse-original@example.com", "5550000300", "password", "Reuse User")
+
+	reqBody, _ := json.Marshal(map[string]string{"new_email": "reuse-new@example.com"})
+	resp, err := client.Post(srv.URL+"/api/me/email", "application/json", bytes.NewReader(reqBody))
+	if err != nil {
+		t.Fatalf("POST /api/me/email: %v", err)
+	}
+	resp.Body.Close()
+
+	msg := waitForMail(t, "reuse-new@example.com", 5*time.Second)
+	text := fetchMailText(t, msg.ID)
+	confirmURL := extractConfirmURL(t, text)
+
+	// Rewrite to test server host.
+	parsed, _ := url.Parse(confirmURL)
+	srvParsed, _ := url.Parse(srv.URL)
+	parsed.Scheme = srvParsed.Scheme
+	parsed.Host = srvParsed.Host
+	localConfirm := parsed.String()
+
+	// First use should succeed.
+	resp, err = http.Get(localConfirm)
+	if err != nil {
+		t.Fatalf("first confirm: %v", err)
+	}
+	resp.Body.Close()
+	if !strings.Contains(resp.Request.URL.String(), "success=email-changed") {
+		t.Errorf("first use: landed on %s, want email-changed", resp.Request.URL)
+	}
+
+	// Second use on same token should return 401.
+	noRedirect := &http.Client{
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+	resp, err = noRedirect.Get(localConfirm)
+	if err != nil {
+		t.Fatalf("second confirm: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("reused confirm token: status = %d, want 401", resp.StatusCode)
+	}
+}
+
+// TestEmailChange_DuplicateEmail checks that requesting a change to an address
+// already owned by another account returns 409 Conflict.
+func TestEmailChange_DuplicateEmail(t *testing.T) {
+	srv, client, _, authSvc, cleanup := testServerWithAccount(t)
+	defer cleanup()
+	purgeMailpit(t)
+
+	// Create a second user that already owns the target address.
+	_, err := authSvc.CreateUser("taken@example.com", "password", "Taken User")
+	if err != nil {
+		t.Fatalf("create taken user: %v", err)
+	}
+
+	signupAndLogin(t, client, srv.URL, "dupuser", "dup-original@example.com", "5550000400", "password", "Dup User")
+
+	reqBody, _ := json.Marshal(map[string]string{"new_email": "taken@example.com"})
+	noRedirect := &http.Client{
+		Jar: client.Jar,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+	resp, err := noRedirect.Post(srv.URL+"/api/me/email", "application/json", bytes.NewReader(reqBody))
+	if err != nil {
+		t.Fatalf("POST /api/me/email: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusConflict {
+		body, _ := io.ReadAll(resp.Body)
+		t.Errorf("duplicate email change: status = %d, want 409 (body: %s)", resp.StatusCode, body)
+	}
+}
+
+// TestDeleteAccount_FullFlow verifies that DELETE /api/me removes the account,
+// clears the session cookie, and subsequent GET /api/me returns 401.
+func TestDeleteAccount_FullFlow(t *testing.T) {
+	srv, client, _, _, cleanup := testServerWithAccount(t)
+	defer cleanup()
+
+	signupAndLogin(t, client, srv.URL, "deleteuser", "delete@example.com", "5550000500", "password", "Delete User")
+
+	// Sanity-check: authenticated before delete.
+	resp, err := client.Get(srv.URL + "/api/me/")
+	if err != nil {
+		t.Fatalf("GET /api/me/ before delete: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("pre-delete /api/me/ status = %d, want 200", resp.StatusCode)
+	}
+
+	// Issue DELETE /api/me/.
+	req, _ := http.NewRequest(http.MethodDelete, srv.URL+"/api/me/", nil)
+	resp, err = client.Do(req)
+	if err != nil {
+		t.Fatalf("DELETE /api/me/: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("DELETE /api/me/ status = %d, body: %s", resp.StatusCode, body)
+	}
+
+	// After deletion, GET /api/me/ should return 401 — session and user are gone.
+	noRedirect := &http.Client{
+		Jar: client.Jar,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+	resp, err = noRedirect.Get(srv.URL + "/api/me/")
+	if err != nil {
+		t.Fatalf("GET /api/me/ after delete: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("after account deletion GET /api/me/: status = %d, want 401", resp.StatusCode)
+	}
+}
+
+// TestDeleteAccount_Unauthenticated checks that DELETE /api/me without a
+// session returns 401 JSON, not a redirect.
+func TestDeleteAccount_Unauthenticated(t *testing.T) {
+	srv, _, _, _, cleanup := testServerWithAccount(t)
+	defer cleanup()
+
+	noRedirect := &http.Client{
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+	req, _ := http.NewRequest(http.MethodDelete, srv.URL+"/api/me/", nil)
+	resp, err := noRedirect.Do(req)
+	if err != nil {
+		t.Fatalf("DELETE /api/me/: %v", err)
+	}
+	resp.Body.Close()
+
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("unauthenticated DELETE /api/me/: status = %d, want 401", resp.StatusCode)
+	}
+}
+
+// TestEmailChange_Unauthenticated checks POST /api/me/email without session.
+func TestEmailChange_Unauthenticated(t *testing.T) {
+	srv, _, _, _, cleanup := testServerWithAccount(t)
+	defer cleanup()
+
+	reqBody, _ := json.Marshal(map[string]string{"new_email": "anything@example.com"})
+	noRedirect := &http.Client{
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+	resp, err := noRedirect.Post(srv.URL+"/api/me/email", "application/json", bytes.NewReader(reqBody))
+	if err != nil {
+		t.Fatalf("POST /api/me/email: %v", err)
+	}
+	resp.Body.Close()
+
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("unauthenticated POST /api/me/email: status = %d, want 401", resp.StatusCode)
+	}
+}
+
+// TestEmailChange_InvalidToken checks GET /auth/email-change with a bogus token.
+func TestEmailChange_InvalidToken(t *testing.T) {
+	srv, _, _, _, cleanup := testServerWithAccount(t)
+	defer cleanup()
+
+	noRedirect := &http.Client{
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+	resp, err := noRedirect.Get(fmt.Sprintf("%s/auth/email-change?token=bogus-token-xyz", srv.URL))
+	if err != nil {
+		t.Fatalf("GET /auth/email-change: %v", err)
+	}
+	resp.Body.Close()
+
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("invalid email change token: status = %d, want 401", resp.StatusCode)
+	}
+}
+
+// TestEmailChange_MissingToken checks GET /auth/email-change with no token param.
+func TestEmailChange_MissingToken(t *testing.T) {
+	srv, _, _, _, cleanup := testServerWithAccount(t)
+	defer cleanup()
+
+	noRedirect := &http.Client{
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+	resp, err := noRedirect.Get(srv.URL + "/auth/email-change")
+	if err != nil {
+		t.Fatalf("GET /auth/email-change: %v", err)
+	}
+	resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("missing token: status = %d, want 400", resp.StatusCode)
+	}
+}

--- a/services/web/src/i18n/en.ts
+++ b/services/web/src/i18n/en.ts
@@ -96,6 +96,28 @@ const en = {
   'dashboard.sessionExpires': 'Expires',
   'dashboard.noSessions': 'No active sessions.',
 
+  // Account page
+  'account.title': 'Account',
+  'account.heading': 'My Account',
+  'account.emailLabel': 'Email',
+  'account.memberSince': 'Member since',
+  'account.lastLogin': 'Last login',
+  'account.status': 'Account status',
+  'account.statusActive': 'Active',
+  'account.statusInactive': 'Inactive',
+  'account.adminBadge': 'Admin',
+  'account.logout': 'Logout',
+  'account.changeEmail': 'Change Email',
+  'account.newEmailLabel': 'New email address',
+  'account.newEmailPlaceholder': 'new@example.com',
+  'account.changeEmailSubmit': 'Send Verification',
+  'account.changeEmailSuccess': "Verification email sent. Click the link to confirm your new address.",
+  'account.deleteAccount': 'Delete Account',
+  'account.deleteConfirm': 'Are you sure? This cannot be undone.',
+  'account.deleteConfirmBtn': 'Yes, delete my account',
+  'account.deleteCancelBtn': 'Cancel',
+  'account.emailChangedSuccess': 'Email address updated successfully.',
+
   // Lies wall
   'lies.title': 'Lies',
   'lies.heading': 'The Wall of Lies',

--- a/services/web/src/i18n/es.ts
+++ b/services/web/src/i18n/es.ts
@@ -98,6 +98,28 @@ const es: Record<TranslationKey, string> = {
   'dashboard.sessionExpires': 'Expira',
   'dashboard.noSessions': 'No hay sesiones activas.',
 
+  // Account page
+  'account.title': 'Cuenta',
+  'account.heading': 'Mi Cuenta',
+  'account.emailLabel': 'Correo electrónico',
+  'account.memberSince': 'Miembro desde',
+  'account.lastLogin': 'Último acceso',
+  'account.status': 'Estado de la cuenta',
+  'account.statusActive': 'Activa',
+  'account.statusInactive': 'Inactiva',
+  'account.adminBadge': 'Admin',
+  'account.logout': 'Cerrar sesión',
+  'account.changeEmail': 'Cambiar correo electrónico',
+  'account.newEmailLabel': 'Nuevo correo electrónico',
+  'account.newEmailPlaceholder': 'nuevo@ejemplo.com',
+  'account.changeEmailSubmit': 'Enviar verificación',
+  'account.changeEmailSuccess': 'Correo de verificación enviado. Haz clic en el enlace para confirmar tu nueva dirección.',
+  'account.deleteAccount': 'Eliminar cuenta',
+  'account.deleteConfirm': '¿Estás seguro? Esto no se puede deshacer.',
+  'account.deleteConfirmBtn': 'Sí, eliminar mi cuenta',
+  'account.deleteCancelBtn': 'Cancelar',
+  'account.emailChangedSuccess': 'Dirección de correo actualizada correctamente.',
+
   // Lies wall
   'lies.title': 'Mentiras',
   'lies.heading': 'El Muro de Mentiras',

--- a/services/web/src/pages/[lang]/account.astro
+++ b/services/web/src/pages/[lang]/account.astro
@@ -1,0 +1,268 @@
+---
+// Account page — shows user info and account management actions.
+// Server-rendered: calls portal /api/me to get the current user.
+// Actions (change email, delete account) are performed via client-side fetch.
+import Base from '../../layouts/Base.astro';
+import Topbar from '../../components/Topbar.astro';
+import { getPortalUrl } from '../../lib/proxy';
+import { isLocale, type Locale } from '../../i18n/config';
+import { t, localePath } from '../../i18n/utils';
+
+const { lang } = Astro.params;
+if (!lang || !isLocale(lang)) return Astro.redirect('/en/account', 302);
+const locale = lang as Locale;
+
+// Redirect to login if no session cookie present.
+const sessionCookie = Astro.cookies.get('session');
+if (!sessionCookie?.value) {
+    return Astro.redirect(localePath(locale, '/login'));
+}
+
+// Fetch current user from portal REST API.
+const portalUrl = getPortalUrl();
+let user: {
+    id: string;
+    email: string;
+    username: string;
+    name: string;
+    is_admin: boolean;
+    is_active: boolean;
+    created_at: string;
+    last_login_at: string;
+} | null = null;
+
+try {
+    const resp = await fetch(`${portalUrl}/api/me/`, {
+        headers: { Cookie: `session=${sessionCookie.value}` },
+    });
+    if (resp.status === 401) {
+        return Astro.redirect(localePath(locale, '/login'));
+    }
+    if (resp.ok) {
+        user = await resp.json();
+    }
+} catch (_err) {
+    return Astro.redirect(localePath(locale, '/login'));
+}
+
+if (!user) {
+    return Astro.redirect(localePath(locale, '/login'));
+}
+
+// Check for success message from email-change confirmation redirect.
+const successParam = Astro.url.searchParams.get('success');
+const emailChangedSuccess = successParam === 'email-changed';
+---
+
+<Base title={t(locale, 'account.title')} lang={locale}>
+    <Topbar slot="topbar" locale={locale} />
+
+    <section class="section">
+        <div class="container">
+            <div class="columns is-centered">
+                <div class="column is-8-tablet is-6-desktop">
+
+                    <h1 class="title is-3 mb-2" style="font-family: 'Montserrat', sans-serif;">
+                        {t(locale, 'account.heading')}
+                        {user.is_admin && (
+                            <span class="tag is-warning is-light ml-3" style="vertical-align: middle; font-size: 0.65rem; font-weight: 600; letter-spacing: 0.05em;">
+                                {t(locale, 'account.adminBadge')}
+                            </span>
+                        )}
+                    </h1>
+
+                    {emailChangedSuccess && (
+                        <div class="notification is-success is-light mb-4">
+                            <span class="icon"><i class="fas fa-check-circle"></i></span>
+                            {t(locale, 'account.emailChangedSuccess')}
+                        </div>
+                    )}
+
+                    <!-- Profile info -->
+                    <div class="box mb-4" style="border-radius: 8px; border: none; box-shadow: 0 2px 12px rgba(0,0,0,0.06);">
+                        <table class="table is-fullwidth is-narrow">
+                            <tbody>
+                                <tr>
+                                    <th style="color: var(--fresh-dark); width: 40%;">{t(locale, 'account.emailLabel')}</th>
+                                    <td style="color: var(--fresh-muted);">{user.email}</td>
+                                </tr>
+                                <tr>
+                                    <th style="color: var(--fresh-dark);">{t(locale, 'account.memberSince')}</th>
+                                    <td style="color: var(--fresh-muted);">
+                                        <time data-iso={user.created_at} data-fmt="date">{user.created_at}</time>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th style="color: var(--fresh-dark);">{t(locale, 'account.lastLogin')}</th>
+                                    <td style="color: var(--fresh-muted);">
+                                        <time data-iso={user.last_login_at} data-fmt="datetime">{user.last_login_at}</time>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th style="color: var(--fresh-dark);">{t(locale, 'account.status')}</th>
+                                    <td>
+                                        {user.is_active
+                                            ? <span class="tag is-success is-light">{t(locale, 'account.statusActive')}</span>
+                                            : <span class="tag is-warning is-light">{t(locale, 'account.statusInactive')}</span>
+                                        }
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+
+                        <div class="mt-4">
+                            <a class="button secondary-btn btn-outlined is-rounded" href="/logout">
+                                <span class="icon"><i class="fas fa-right-from-bracket"></i></span>
+                                <span>{t(locale, 'account.logout')}</span>
+                            </a>
+                        </div>
+                    </div>
+
+                    <!-- Change email -->
+                    <div class="box mb-4" style="border-radius: 8px; border: none; box-shadow: 0 2px 12px rgba(0,0,0,0.06);">
+                        <h2 class="title is-5 mb-4">{t(locale, 'account.changeEmail')}</h2>
+                        <div id="email-feedback" class="notification is-hidden mb-3" role="alert"></div>
+                        <form id="change-email-form">
+                            <div class="field has-addons">
+                                <div class="control is-expanded">
+                                    <input
+                                        class="input"
+                                        type="email"
+                                        id="new-email"
+                                        name="new_email"
+                                        placeholder={t(locale, 'account.newEmailPlaceholder')}
+                                        required
+                                    />
+                                </div>
+                                <div class="control">
+                                    <button class="button primary-btn is-rounded" type="submit">
+                                        {t(locale, 'account.changeEmailSubmit')}
+                                    </button>
+                                </div>
+                            </div>
+                        </form>
+                    </div>
+
+                    <!-- Delete account -->
+                    <div class="box" style="border-radius: 8px; border: 1px solid rgba(255,80,80,0.2); box-shadow: 0 2px 12px rgba(0,0,0,0.06);">
+                        <h2 class="title is-5 mb-2" style="color: var(--fresh-danger, #e74c3c);">{t(locale, 'account.deleteAccount')}</h2>
+                        <p class="is-size-7 mb-4" style="color: var(--fresh-muted);">{t(locale, 'account.deleteConfirm')}</p>
+                        <div id="delete-confirmation" class="is-hidden">
+                            <div class="buttons">
+                                <button id="confirm-delete-btn" class="button is-danger is-rounded">
+                                    <span class="icon"><i class="fas fa-trash"></i></span>
+                                    <span>{t(locale, 'account.deleteConfirmBtn')}</span>
+                                </button>
+                                <button id="cancel-delete-btn" class="button is-light is-rounded">
+                                    {t(locale, 'account.deleteCancelBtn')}
+                                </button>
+                            </div>
+                        </div>
+                        <button id="delete-account-btn" class="button is-danger is-outlined is-rounded">
+                            <span class="icon"><i class="fas fa-trash-alt"></i></span>
+                            <span>{t(locale, 'account.deleteAccount')}</span>
+                        </button>
+                    </div>
+
+                </div>
+            </div>
+        </div>
+    </section>
+</Base>
+
+<script>
+// Client-side timezone-aware date formatting (same pattern as dashboard).
+document.querySelectorAll('time[data-iso]').forEach((el) => {
+    const iso = el.getAttribute('data-iso');
+    if (!iso) return;
+    try {
+        const date = new Date(iso);
+        if (isNaN(date.getTime())) return;
+        const fmt = el.getAttribute('data-fmt');
+        const opts: Intl.DateTimeFormatOptions = fmt === 'date'
+            ? { month: 'short', day: 'numeric', year: 'numeric' }
+            : { month: 'short', day: 'numeric', year: 'numeric', hour: 'numeric', minute: '2-digit' };
+        el.textContent = new Intl.DateTimeFormat(undefined, opts).format(date);
+    } catch {
+        // Leave ISO string as-is on formatting failure.
+    }
+});
+
+// --- Change email form ---
+const emailForm = document.getElementById('change-email-form') as HTMLFormElement | null;
+const emailFeedback = document.getElementById('email-feedback') as HTMLDivElement | null;
+
+function showFeedback(el: HTMLElement | null, msg: string, isSuccess: boolean) {
+    if (!el) return;
+    el.textContent = msg;
+    el.className = `notification ${isSuccess ? 'is-success' : 'is-danger'} is-light mb-3`;
+}
+
+emailForm?.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const input = document.getElementById('new-email') as HTMLInputElement | null;
+    const newEmail = input?.value.trim() ?? '';
+    if (!newEmail) return;
+
+    const submitBtn = emailForm.querySelector('button[type="submit"]') as HTMLButtonElement | null;
+    if (submitBtn) submitBtn.disabled = true;
+
+    try {
+        const resp = await fetch('/api/me/email', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ new_email: newEmail }),
+        });
+        const data: { message?: string; error?: string } = await resp.json();
+        if (resp.ok) {
+            showFeedback(emailFeedback, data.message ?? 'Verification email sent.', true);
+            if (input) input.value = '';
+        } else {
+            showFeedback(emailFeedback, data.error ?? 'Something went wrong.', false);
+        }
+    } catch {
+        showFeedback(emailFeedback, 'Network error. Please try again.', false);
+    } finally {
+        if (submitBtn) submitBtn.disabled = false;
+    }
+});
+
+// --- Delete account flow ---
+const deleteBtn = document.getElementById('delete-account-btn') as HTMLButtonElement | null;
+const deleteConfirmation = document.getElementById('delete-confirmation') as HTMLDivElement | null;
+const confirmDeleteBtn = document.getElementById('confirm-delete-btn') as HTMLButtonElement | null;
+const cancelDeleteBtn = document.getElementById('cancel-delete-btn') as HTMLButtonElement | null;
+
+deleteBtn?.addEventListener('click', () => {
+    deleteBtn.classList.add('is-hidden');
+    deleteConfirmation?.classList.remove('is-hidden');
+});
+
+cancelDeleteBtn?.addEventListener('click', () => {
+    deleteConfirmation?.classList.add('is-hidden');
+    deleteBtn?.classList.remove('is-hidden');
+});
+
+confirmDeleteBtn?.addEventListener('click', async () => {
+    if (confirmDeleteBtn) confirmDeleteBtn.disabled = true;
+
+    try {
+        const resp = await fetch('/api/me/', { method: 'DELETE' });
+        if (resp.ok || resp.status === 204) {
+            // Account deleted — redirect to home.
+            window.location.href = '/';
+        } else {
+            const data: { error?: string } = await resp.json().catch(() => ({}));
+            alert(data.error ?? 'Failed to delete account. Please try again.');
+            deleteConfirmation?.classList.add('is-hidden');
+            deleteBtn?.classList.remove('is-hidden');
+        }
+    } catch {
+        alert('Network error. Please try again.');
+        deleteConfirmation?.classList.add('is-hidden');
+        deleteBtn?.classList.remove('is-hidden');
+    } finally {
+        if (confirmDeleteBtn) confirmDeleteBtn.disabled = false;
+    }
+});
+</script>

--- a/services/web/src/pages/[lang]/login.astro
+++ b/services/web/src/pages/[lang]/login.astro
@@ -21,10 +21,17 @@ if (Astro.request.method === 'POST') {
   // Rewrite portal redirects to locale-prefixed paths.
   if (resp.status >= 300 && resp.status < 400) {
     const location = resp.headers.get('Location') || '';
+    // Build a clean redirect — never spread resp.headers, which can produce
+    // multi-value Location strings like "/dashboard, /en/dashboard".
+    const redirectHeaders: Record<string, string> = {};
+    // Forward Set-Cookie so the session cookie reaches the browser.
+    const setCookie = resp.headers.get('set-cookie');
+    if (setCookie) redirectHeaders['set-cookie'] = setCookie;
+
     if (location === '/dashboard' || location.endsWith('/dashboard')) {
       return new Response(null, {
         status: resp.status,
-        headers: { ...Object.fromEntries(resp.headers), Location: localePath(locale, '/dashboard') },
+        headers: { ...redirectHeaders, Location: localePath(locale, '/dashboard') },
       });
     }
     // Rewrite error redirects back to locale-prefixed login.
@@ -32,7 +39,7 @@ if (Astro.request.method === 'POST') {
       const search = location.includes('?') ? location.substring(location.indexOf('?')) : '';
       return new Response(null, {
         status: resp.status,
-        headers: { ...Object.fromEntries(resp.headers), Location: localePath(locale, '/login') + search },
+        headers: { ...redirectHeaders, Location: localePath(locale, '/login') + search },
       });
     }
   }

--- a/services/web/src/pages/[lang]/signup.astro
+++ b/services/web/src/pages/[lang]/signup.astro
@@ -17,17 +17,23 @@ if (Astro.request.method === 'POST') {
   // Rewrite portal redirects to locale-prefixed paths.
   if (resp.status >= 300 && resp.status < 400) {
     const location = resp.headers.get('Location') || '';
+    // Build a clean redirect — never spread resp.headers, which can produce
+    // multi-value Location strings like "/dashboard, /en/dashboard".
+    const redirectHeaders: Record<string, string> = {};
+    const setCookie = resp.headers.get('set-cookie');
+    if (setCookie) redirectHeaders['set-cookie'] = setCookie;
+
     if (location === '/dashboard' || location.endsWith('/dashboard')) {
       return new Response(null, {
         status: resp.status,
-        headers: { ...Object.fromEntries(resp.headers), Location: localePath(locale, '/dashboard') },
+        headers: { ...redirectHeaders, Location: localePath(locale, '/dashboard') },
       });
     }
     if (location.startsWith('/signup')) {
       const search = location.includes('?') ? location.substring(location.indexOf('?')) : '';
       return new Response(null, {
         status: resp.status,
-        headers: { ...Object.fromEntries(resp.headers), Location: localePath(locale, '/signup') + search },
+        headers: { ...redirectHeaders, Location: localePath(locale, '/signup') + search },
       });
     }
   }


### PR DESCRIPTION
## Summary

portal account page — user info, email change, delete account

## Changes

- **Commits**: 39 (will be squashed)
- **Changes**: 32 files changed, 2244 insertions(+), 124 deletions(-)

## Files Changed

- `~` .github/workflows/deploy-deadman-dev.yml
- `~` cmd/deadman/Dockerfile
- `+` cmd/deadman/PRIVACY.txt
- `~` cmd/deadman/entrypoint.sh
- `~` cmd/deadman/main.go
- `~` internal/deadman/sms.go
- `+` internal/deadman/test_endpoints.go
- `~` internal/deadman/twilio.go
- `+` services/deadman/terraform/environments/dev/.terraform.lock.hcl
- `+` services/deadman/terraform/environments/dev/import.sh
- `~` services/deadman/terraform/environments/dev/main.tf
- `~` services/deadman/terraform/environments/dev/outputs.tf
- `~` services/deadman/terraform/environments/dev/variables.tf
- `~` services/deadman/terraform/modules/cloud-run/main.tf
- `+` services/deadman/terraform/modules/cloud-sql/main.tf
- `+` services/deadman/terraform/modules/dns/main.tf
- `~` services/deadman/terraform/modules/secrets/main.tf
- `~` services/portal/cmd/server/main.go
- `~` services/portal/config/config.go
- `~` services/portal/internal/auth/errors.go
- `~` services/portal/internal/auth/service.go
- `~` services/portal/internal/database/database.go
- `+` services/portal/internal/mailer/mailer.go
- `~` services/portal/internal/web/handlers/handlers.go
- `~` services/portal/internal/web/handlers/middleware.go
- `~` services/portal/pkg/models/models.go
- `+` services/portal/tests/integration/account_test.go
- `~` services/web/src/i18n/en.ts
- `~` services/web/src/i18n/es.ts
- `+` services/web/src/pages/[lang]/account.astro
- `~` services/web/src/pages/[lang]/login.astro
- `~` services/web/src/pages/[lang]/signup.astro

---

*Auto-generated from workstream: workstream_portal-account-page-user-info-email-change-delete-8c5c1b96*
